### PR TITLE
UI opacity graph fixes

### DIFF
--- a/frontend-new/src/components/Anomaly/index.jsx
+++ b/frontend-new/src/components/Anomaly/index.jsx
@@ -199,7 +199,7 @@ const Anomaly = ({ kpi }) => {
             lineWidth: 0,
             linkedTo: ':previous',
             color: '#60CA9A',
-            fillOpacity: 0.1,
+            fillOpacity: 0.2,
             zIndex: 0,
             states: {
               inactive: {

--- a/frontend-new/src/components/Anomalygraph/index.jsx
+++ b/frontend-new/src/components/Anomalygraph/index.jsx
@@ -161,7 +161,7 @@ const Anomalygraph = ({ key, drilldown }) => {
             lineWidth: 0,
             linkedTo: ':previous',
             color: '#60CA9A',
-            fillOpacity: 0.1,
+            fillOpacity: 0.2,
             zIndex: 0,
             marker: {
               fillColor: 'grey',


### PR DESCRIPTION
1. Changed opacity of graphs to increase CI visibility
2. For DQ and Subdim Graphs: 
    - Added datetime to tooltip
    - Fixed error where value was lower limit of the CI