### PR TITLE
fix(anomaly): added slack to minimum threshold

### DIFF
--- a/chaos_genius/core/anomaly/controller.py
+++ b/chaos_genius/core/anomaly/controller.py
@@ -31,6 +31,7 @@ class AnomalyDetectionController(object):
         self.debug = self.kpi_info['anomaly_params'].get('debug', False)
         if self.debug == "True": self.debug = True
         if self.debug == "False": self.debug = False
+        self.slack = self.kpi_info['anomaly_params'].get('slack', 3)
 
     def _load_anomaly_data(self) -> pd.DataFrame:
         """Loads KPI data from its datastore, preprocesses it and
@@ -129,6 +130,7 @@ class AnomalyDetectionController(object):
             self.kpi_info["table_name"],
             freq,
             sensitivity,
+            self.slack,
             series,
             subgroup,
             self.kpi_info.get("model_kwargs", {})

--- a/chaos_genius/core/anomaly/processor.py
+++ b/chaos_genius/core/anomaly/processor.py
@@ -17,6 +17,7 @@ class ProcessAnomalyDetection:
         table_name: str,
         freq: str,
         sensitivity: str,
+        slack: int,
         series: str,
         subgroup: str = None,
         model_kwargs={},
@@ -32,6 +33,7 @@ class ProcessAnomalyDetection:
         self.model_kwargs = model_kwargs
         self.freq = freq
         self.sensitivity = sensitivity
+        self.slack = slack
 
     def predict(self):
 
@@ -61,7 +63,8 @@ class ProcessAnomalyDetection:
 
         if self.last_date is None:
             # pass complete input data frame in here as pred_df
-            if len(input_data) >= self.period:
+            if self.period-len(input_data) <= self.slack:
+
                 prediction = model.predict(
                     input_data,
                     self.sensitivity,


### PR DESCRIPTION
for batch training configurable variable slack added in anomaly params
that can be used to adjust for recently missing data

This bug occurs when the recent data is missing and we batch train, causing the size of the input data to be less than the minimum period defined, this means that the data can not be batch trained.

To fix this we have added a condition that allows the data to be batch trained if the difference between the period and the length of the input data is less then a certain amount (variable called slack)