### PR TITLE
fix: add api to GET anomaly_params for kpi

### DIFF
--- a/chaos_genius/views/anomaly_data_view.py
+++ b/chaos_genius/views/anomaly_data_view.py
@@ -595,7 +595,6 @@ def validate_partial_scheduler_params(scheduler_params: Dict[str, Any]) -> Tuple
     return "", scheduler_params
 
 
-<<<<<<< HEAD
 @blueprint.route("/<int:kpi_id>/settings", methods=["GET"])
 # @cache.memoize(timeout=30000)
 def anomaly_settings_status(kpi_id):


### PR DESCRIPTION
Added a kpi to get anomaly_params for a particular kpi, along with an 'is_setup' flag
