### PR TITLE
fix(anomaly-params): make meta info a flat structure

### DIFF
--- a/chaos_genius/views/anomaly_data_view.py
+++ b/chaos_genius/views/anomaly_data_view.py
@@ -448,15 +448,10 @@ ANOMALY_PARAMS_META = {
             ]
         },
         {
-            "name": "scheduler_params",
-            "fields": [
-                {
-                    "name": "time",
-                    "is_editable": True,
-                    "is_sensitive": False,
-                    "type": "time",
-                },
-            ],
+            "name": "scheduler_params_time",
+            "is_editable": True,
+            "is_sensitive": False,
+            "type": "time",
         },
     ],
 }


### PR DESCRIPTION
The field name ("time") has been changed to include the parent field as well.