### PR TITLE
fix(docker): add REACT_APP_BASE_URL in .env for server config

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,7 @@
+# backend API URL used in frontend
+# replace localhost with server's IP if not running on local system
+REACT_APP_BASE_URL=http://localhost:5000
+
 FLASK_APP=run
 FLASK_ENV=production
 FLASK_DEBUG=0
@@ -22,6 +26,9 @@ CELERY_BROKER_URL=redis://chaosgenius-redis:6379/1
 
 # Docker volume mounts
 CG_DB_DOCKER_MOUNT=cg_db
+
+# Caching timeout for APIs
+CACHE_DEFAULT_TIMEOUT=1
 
 # === airbyte env vars start here ===
 VERSION=0.29.12-alpha
@@ -113,6 +120,3 @@ MAX_SYNC_JOB_ATTEMPTS=3
 
 # Time in days to reach a timeout to cancel the synchronization
 MAX_SYNC_TIMEOUT_DAYS=3
-
-# Caching timeout for APIs
-CACHE_DEFAULT_TIMEOUT=1

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -41,7 +41,7 @@ services:
       - NODE_ENV=production
       - HOST=0.0.0.0
       - PORT=3000
-      - REACT_APP_BASE_URL=http://localhost:5000
+      - REACT_APP_BASE_URL=${REACT_APP_BASE_URL}
     stdin_open: true
     command: npm run start
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - NODE_ENV=production
       - HOST=0.0.0.0
       - PORT=3000
-      - REACT_APP_BASE_URL=http://localhost:5000
+      - REACT_APP_BASE_URL=${REACT_APP_BASE_URL}
     stdin_open: true
     command: npm run start
 


### PR DESCRIPTION
REACT_APP_BASE_URL needs to be set correctly when using the compose deployment on a server.

Also moved caching timeout to the top