### PR TITLE
feat: kpi validation max rows now uses count

### DIFF
--- a/chaos_genius/core/rca/rca_controller.py
+++ b/chaos_genius/core/rca/rca_controller.py
@@ -59,7 +59,8 @@ class RootCauseAnalysisController:
     def _load_data(
         self,
         timeline: str = "mom",
-        tail: int = None
+        tail: int = None,
+        get_count: bool = False
     ) -> Tuple[pd.DataFrame, pd.DataFrame]:
         """Load data for performing RCA.
 
@@ -67,13 +68,18 @@ class RootCauseAnalysisController:
         :type timeline: str, optional
         :param tail: limit data loaded to this number of rows, defaults to None
         :type tail: int, optional
+        :param get_count: Return count values of data, defaults to False
+        :type get_count: bool, optional
         :return: tuple with baseline data and rca data for
         :rtype: Tuple[pd.DataFrame, pd.DataFrame]
         """
         base_df, rca_df = rca_load_data(
             self.kpi_info, self.connection_info, self.dt_col, self.end_date,
-            timeline, tail)
-        logger.info(f"Loaded {len(base_df)}, {len(rca_df)} rows of data")
+            timeline, tail, get_count)
+        if get_count:
+            logger.info(f"Loaded {base_df}, {rca_df} rows of data")
+        else:
+            logger.info(f"Loaded {len(base_df)}, {len(rca_df)} rows of data")
         return base_df, rca_df
 
     def _output_to_row(

--- a/chaos_genius/core/utils/kpi_validation.py
+++ b/chaos_genius/core/utils/kpi_validation.py
@@ -302,13 +302,13 @@ def _validate_for_maximum_kpi_size(
     """
     try:
         rca = RootCauseAnalysisController(kpi_info)
-        base_df, rca_df = rca._load_data()
-        df = pd.concat([base_df, rca_df])
+        base_df, rca_df = rca._load_data(get_count=True)
+        df = base_df + rca_df
     except Exception as e:  # noqa: B902
         return False, "Could not load data. Error: " + str(e)
     valid_str = "Accepted!"
 
-    if len(df) <= num_rows:
+    if df <= num_rows:
         return True, valid_str
 
     error_message = (
@@ -316,5 +316,4 @@ def _validate_for_maximum_kpi_size(
         f"monthly rows greater than {num_rows}. Please try materialized views"
         "for such datasets (coming soon)."
     )
-
     return False, error_message


### PR DESCRIPTION
For kpi validation, when we check for max number of rows,
we now load count of rows instead of loading entire data and
then counting.

By @kartikay-bagla 