### PR TITLE
feat(logging): add fluentd based logging

### DIFF
--- a/docker-compose.fluentd.yml
+++ b/docker-compose.fluentd.yml
@@ -1,0 +1,379 @@
+version: "3.7"
+#https://github.com/compose-spec/compose-spec/blob/master/spec.md#using-extensions-as-fragments
+x-logging: &default-logging
+  options:
+    fluentd-address: localhost:24224
+    fluentd-async: "true"
+  driver: fluentd
+
+services:
+  chaosgenius-init:
+    container_name: chaosgenius-init
+    image: docker:latest
+    command: >
+      sh -c "apk update && 
+             apk upgrade && 
+             apk add bash && 
+             bash /setup/docker/setup-airbyte-images.sh"
+    volumes:
+      - ./setup:/setup
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - SOURCE_GOOGLE_ANALYTICS=${SOURCE_GOOGLE_ANALYTICS}
+      - SOURCE_GOOGLE_SHEETS=${SOURCE_GOOGLE_SHEETS}
+      - SOURCE_MYSQL=${SOURCE_MYSQL}
+      - SOURCE_POSTGRES=${SOURCE_POSTGRES}
+      - SOURCE_SHOPIFY=${SOURCE_SHOPIFY}
+      - SOURCE_STRIPE=${SOURCE_STRIPE}
+      - SOURCE_GOOGLE_ADS=${SOURCE_GOOGLE_ADS}
+      - SOURCE_FACEBOOK_ADS=${SOURCE_FACEBOOK_ADS}
+      - SOURCE_BING_ADS=${SOURCE_BING_ADS}
+      - SOURCE_GOOGLE_BIG_QUERY=${SOURCE_GOOGLE_BIG_QUERY}
+      - SOURCE_SNOWFLAKE=${SOURCE_SNOWFLAKE}
+
+  chaosgenius-fluentd:
+    container_name: chaosgenius-fluentd
+    image: fluent/fluentd:latest
+    environment:
+      - FLUENTD_CONF=log.conf
+      - FLUENT_UID=0
+    ports:
+      - 24224:24224
+    volumes:
+      - ./setup/fluentd/log.conf:/fluentd/etc/log.conf
+      - ./logs:/var/log/fluent
+
+  chaosgenius-webapp:
+    container_name: chaosgenius-webapp
+    image: chaosgenius/chaosgenius-webapp:latest
+    ports:
+      - "8080:3000"
+    environment:
+      - NODE_ENV=production
+      - HOST=0.0.0.0
+      - PORT=3000
+      - REACT_APP_BASE_URL=${REACT_APP_BASE_URL}
+    stdin_open: true
+    command: npm run start
+    logging: *default-logging
+    depends_on:
+      - chaosgenius-fluentd
+
+  chaosgenius-server:
+    container_name: chaosgenius-server
+    image: chaosgenius/chaosgenius-server:latest
+    command: sh setup/run-backend-docker.sh
+    ports:
+      - "5000:5000"
+    depends_on:
+      - chaosgenius-db
+      - server
+      - chaosgenius-fluentd
+    environment:
+      - FLASK_APP=${FLASK_APP}
+      - FLASK_ENV=${FLASK_ENV}
+      - FLASK_DEBUG=${FLASK_DEBUG}
+      - FLASK_RUN_PORT=${FLASK_RUN_PORT}
+      - SECRET_KEY=${SECRET_KEY}
+      - SEND_FILE_MAX_AGE_DEFAULT=${SEND_FILE_MAX_AGE_DEFAULT}
+      - DB_HOST=${DB_HOST}
+      - DB_USERNAME=${DB_USERNAME}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - DB_PORT=${DB_PORT}
+      - META_DATABASE=${META_DATABASE}
+      - DATA_DATABASE=${DATA_DATABASE}
+      - DATABASE_URL_CG_DB=${DATABASE_URL_CG_DB}
+      - INTEGRATION_SERVER=${INTEGRATION_SERVER}
+      - INTEGRATION_DB_HOST=${INTEGRATION_DB_HOST}
+      - INTEGRATION_DB_USERNAME=${INTEGRATION_DB_USERNAME}
+      - INTEGRATION_DB_PASSWORD=${INTEGRATION_DB_PASSWORD}
+      - INTEGRATION_DB_PORT=${INTEGRATION_DB_PORT}
+      - INTEGRATION_DATABASE=${INTEGRATION_DATABASE}
+      - CELERY_RESULT_BACKEND=${CELERY_RESULT_BACKEND}
+      - CELERY_BROKER_URL=${CELERY_BROKER_URL}
+      - CACHE_DEFAULT_TIMEOUT=${CACHE_DEFAULT_TIMEOUT}
+    logging: *default-logging
+
+  chaosgenius-db:
+    container_name: chaosgenius-db
+    image: postgres:13
+    restart: always
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-q", "-d", "chaosgenius_data", "-U", "postgres" ]
+      timeout: 45s
+      interval: 10s
+      retries: 10
+    restart: always
+    environment:
+      - POSTGRES_USER=${DB_USERNAME}
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+    volumes:
+      - ./docker/cg-db-setup:/docker-entrypoint-initdb.d/
+      - cg-db:/var/lib/postgresql/data
+    ports:
+      - 5433:5432
+    logging: *default-logging
+    depends_on:
+      - chaosgenius-fluentd
+
+  chaosgenius-redis:
+    container_name: chaosgenius-redis
+    image: "redis:6.2-alpine"
+    ports:
+      - 6379:6379
+    logging: *default-logging
+    depends_on:
+      - chaosgenius-fluentd
+    
+  chaosgenius-scheduler:
+    container_name: chaosgenius-scheduler
+    image: chaosgenius/chaosgenius-server:latest
+    command: celery -A run.celery beat --loglevel=DEBUG
+    environment:
+      - FLASK_APP=${FLASK_APP}
+      - FLASK_ENV=${FLASK_ENV}
+      - FLASK_DEBUG=${FLASK_DEBUG}
+      - FLASK_RUN_PORT=${FLASK_RUN_PORT}
+      - SECRET_KEY=${SECRET_KEY}
+      - SEND_FILE_MAX_AGE_DEFAULT=${SEND_FILE_MAX_AGE_DEFAULT}
+      - DB_HOST=${DB_HOST}
+      - DB_USERNAME=${DB_USERNAME}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - DB_PORT=${DB_PORT}
+      - META_DATABASE=${META_DATABASE}
+      - DATA_DATABASE=${DATA_DATABASE}
+      - DATABASE_URL_CG_DB=${DATABASE_URL_CG_DB}
+      - INTEGRATION_SERVER=${INTEGRATION_SERVER}
+      - INTEGRATION_DB_HOST=${INTEGRATION_DB_HOST}
+      - INTEGRATION_DB_USERNAME=${INTEGRATION_DB_USERNAME}
+      - INTEGRATION_DB_PASSWORD=${INTEGRATION_DB_PASSWORD}
+      - INTEGRATION_DB_PORT=${INTEGRATION_DB_PORT}
+      - INTEGRATION_DATABASE=${INTEGRATION_DATABASE}
+      - CELERY_RESULT_BACKEND=${CELERY_RESULT_BACKEND}
+      - CELERY_BROKER_URL=${CELERY_BROKER_URL}
+    depends_on:
+      - chaosgenius-redis
+      - chaosgenius-fluentd
+    logging: *default-logging
+  
+  chaosgenius-worker-analytics:
+    container_name: chaosgenius-worker-analytics
+    image: chaosgenius/chaosgenius-server:latest
+    command: celery -A run.celery worker --loglevel=INFO --concurrency=2 -P processes -Q anomaly-rca
+    environment:
+      - FLASK_APP=${FLASK_APP}
+      - FLASK_ENV=${FLASK_ENV}
+      - FLASK_DEBUG=${FLASK_DEBUG}
+      - FLASK_RUN_PORT=${FLASK_RUN_PORT}
+      - SECRET_KEY=${SECRET_KEY}
+      - SEND_FILE_MAX_AGE_DEFAULT=${SEND_FILE_MAX_AGE_DEFAULT}
+      - DB_HOST=${DB_HOST}
+      - DB_USERNAME=${DB_USERNAME}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - DB_PORT=${DB_PORT}
+      - META_DATABASE=${META_DATABASE}
+      - DATA_DATABASE=${DATA_DATABASE}
+      - DATABASE_URL_CG_DB=${DATABASE_URL_CG_DB}
+      - INTEGRATION_SERVER=${INTEGRATION_SERVER}
+      - INTEGRATION_DB_HOST=${INTEGRATION_DB_HOST}
+      - INTEGRATION_DB_USERNAME=${INTEGRATION_DB_USERNAME}
+      - INTEGRATION_DB_PASSWORD=${INTEGRATION_DB_PASSWORD}
+      - INTEGRATION_DB_PORT=${INTEGRATION_DB_PORT}
+      - INTEGRATION_DATABASE=${INTEGRATION_DATABASE}
+      - CELERY_RESULT_BACKEND=${CELERY_RESULT_BACKEND}
+      - CELERY_BROKER_URL=${CELERY_BROKER_URL}
+    depends_on:
+      - chaosgenius-redis
+      - chaosgenius-db
+      - chaosgenius-fluentd
+    logging: *default-logging
+
+  chaosgenius-worker-alerts:
+    container_name: chaosgenius-worker-alerts
+    image: chaosgenius/chaosgenius-server:latest
+    command: celery -A run.celery worker --loglevel=INFO --concurrency=2 -P processes -Q alerts
+    environment:
+      - FLASK_APP=${FLASK_APP}
+      - FLASK_ENV=${FLASK_ENV}
+      - FLASK_DEBUG=${FLASK_DEBUG}
+      - FLASK_RUN_PORT=${FLASK_RUN_PORT}
+      - SECRET_KEY=${SECRET_KEY}
+      - SEND_FILE_MAX_AGE_DEFAULT=${SEND_FILE_MAX_AGE_DEFAULT}
+      - DB_HOST=${DB_HOST}
+      - DB_USERNAME=${DB_USERNAME}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - DB_PORT=${DB_PORT}
+      - META_DATABASE=${META_DATABASE}
+      - DATA_DATABASE=${DATA_DATABASE}
+      - DATABASE_URL_CG_DB=${DATABASE_URL_CG_DB}
+      - INTEGRATION_SERVER=${INTEGRATION_SERVER}
+      - INTEGRATION_DB_HOST=${INTEGRATION_DB_HOST}
+      - INTEGRATION_DB_USERNAME=${INTEGRATION_DB_USERNAME}
+      - INTEGRATION_DB_PASSWORD=${INTEGRATION_DB_PASSWORD}
+      - INTEGRATION_DB_PORT=${INTEGRATION_DB_PORT}
+      - INTEGRATION_DATABASE=${INTEGRATION_DATABASE}
+      - CELERY_RESULT_BACKEND=${CELERY_RESULT_BACKEND}
+      - CELERY_BROKER_URL=${CELERY_BROKER_URL}
+    depends_on:
+      - chaosgenius-redis
+      - chaosgenius-db
+      - chaosgenius-fluentd
+    logging: *default-logging
+
+  # == airbyte services start here ==
+  #
+  # hook in case we need to add init behavior
+  # every root service (no depends_on) should depend on init
+  init:
+    image: airbyte/init:${VERSION}
+    logging: *default-logging
+    container_name: init
+    command: /bin/sh -c "./scripts/create_mount_directories.sh /local_parent ${HACK_LOCAL_ROOT_PARENT} ${LOCAL_ROOT}"
+    environment:
+      - LOCAL_ROOT=${LOCAL_ROOT}
+      - HACK_LOCAL_ROOT_PARENT=${HACK_LOCAL_ROOT_PARENT}
+    volumes:
+      - ${HACK_LOCAL_ROOT_PARENT}:/local_parent
+    depends_on:
+      - chaosgenius-fluentd
+  db:
+    image: airbyte/db:${VERSION}
+    logging: *default-logging
+    container_name: airbyte-db
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=${DATABASE_USER}
+      - POSTGRES_PASSWORD=${DATABASE_PASSWORD}
+    volumes:
+      - db:/var/lib/postgresql/data
+    depends_on:
+      - chaosgenius-fluentd
+  scheduler:
+    image: airbyte/scheduler:${VERSION}
+    logging: *default-logging
+    container_name: airbyte-scheduler
+    restart: unless-stopped
+    environment:
+      - WEBAPP_URL=${WEBAPP_URL}
+      - DATABASE_USER=${DATABASE_USER}
+      - DATABASE_PASSWORD=${DATABASE_PASSWORD}
+      - DATABASE_URL=${DATABASE_URL}
+      - CONFIG_DATABASE_USER=${CONFIG_DATABASE_USER:-}
+      - CONFIG_DATABASE_PASSWORD=${CONFIG_DATABASE_PASSWORD:-}
+      - CONFIG_DATABASE_URL=${CONFIG_DATABASE_URL:-}
+      - WORKSPACE_ROOT=${WORKSPACE_ROOT}
+      - WORKSPACE_DOCKER_MOUNT=${WORKSPACE_DOCKER_MOUNT}
+      - LOCAL_ROOT=${LOCAL_ROOT}
+      - LOCAL_DOCKER_MOUNT=${LOCAL_DOCKER_MOUNT}
+      - CONFIG_ROOT=${CONFIG_ROOT}
+      - TRACKING_STRATEGY=${TRACKING_STRATEGY}
+      - AIRBYTE_VERSION=${VERSION}
+      - AIRBYTE_ROLE=${AIRBYTE_ROLE:-}
+      - TEMPORAL_HOST=${TEMPORAL_HOST}
+      - WORKER_ENVIRONMENT=${WORKER_ENVIRONMENT}
+      - S3_LOG_BUCKET=${S3_LOG_BUCKET}
+      - S3_LOG_BUCKET_REGION=${S3_LOG_BUCKET_REGION}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - GCP_STORAGE_BUCKET=${GCP_STORAGE_BUCKET}
+      - LOG_LEVEL=${LOG_LEVEL}
+      - SUBMITTER_NUM_THREADS=${SUBMITTER_NUM_THREADS}
+      - RESOURCE_CPU_REQUEST=${RESOURCE_CPU_REQUEST}
+      - RESOURCE_CPU_LIMIT=${RESOURCE_CPU_LIMIT}
+      - RESOURCE_MEMORY_REQUEST=${RESOURCE_MEMORY_REQUEST}
+      - RESOURCE_MEMORY_LIMIT=${RESOURCE_MEMORY_LIMIT}
+      - MAX_SYNC_JOB_ATTEMPTS=${MAX_SYNC_JOB_ATTEMPTS}
+      - MAX_SYNC_TIMEOUT_DAYS=${MAX_SYNC_TIMEOUT_DAYS}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - workspace:${WORKSPACE_ROOT}
+      - ${LOCAL_ROOT}:${LOCAL_ROOT}
+      - data:${CONFIG_ROOT}
+    depends_on:
+      - chaosgenius-fluentd
+  server:
+    image: airbyte/server:${VERSION}
+    logging: *default-logging
+    container_name: airbyte-server
+    restart: unless-stopped
+    environment:
+      - WEBAPP_URL=${WEBAPP_URL}
+      - DATABASE_USER=${DATABASE_USER}
+      - DATABASE_PASSWORD=${DATABASE_PASSWORD}
+      - DATABASE_URL=${DATABASE_URL}
+      - CONFIG_DATABASE_USER=${CONFIG_DATABASE_USER:-}
+      - CONFIG_DATABASE_PASSWORD=${CONFIG_DATABASE_PASSWORD:-}
+      - CONFIG_DATABASE_URL=${CONFIG_DATABASE_URL:-}
+      - WORKSPACE_ROOT=${WORKSPACE_ROOT}
+      - CONFIG_ROOT=${CONFIG_ROOT}
+      - TRACKING_STRATEGY=${TRACKING_STRATEGY}
+      - AIRBYTE_VERSION=${VERSION}
+      - AIRBYTE_ROLE=${AIRBYTE_ROLE:-}
+      - TEMPORAL_HOST=${TEMPORAL_HOST}
+      - WORKER_ENVIRONMENT=${WORKER_ENVIRONMENT}
+      - S3_LOG_BUCKET=${S3_LOG_BUCKET}
+      - S3_LOG_BUCKET_REGION=${S3_LOG_BUCKET_REGION}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - GCP_STORAGE_BUCKET=${GCP_STORAGE_BUCKET}
+      - LOG_LEVEL=${LOG_LEVEL}
+      - RESOURCE_CPU_REQUEST=${RESOURCE_CPU_REQUEST}
+      - RESOURCE_CPU_LIMIT=${RESOURCE_CPU_LIMIT}
+      - RESOURCE_MEMORY_REQUEST=${RESOURCE_MEMORY_REQUEST}
+      - RESOURCE_MEMORY_LIMIT=${RESOURCE_MEMORY_LIMIT}
+    ports:
+      - 8001:8001
+    volumes:
+      - workspace:${WORKSPACE_ROOT}
+      - data:${CONFIG_ROOT}
+      - ${LOCAL_ROOT}:${LOCAL_ROOT}
+    depends_on:
+      - chaosgenius-fluentd
+  webapp:
+    image: airbyte/webapp:${VERSION}
+    logging: *default-logging
+    container_name: airbyte-webapp
+    restart: unless-stopped
+    ports:
+      - 8000:80
+    environment:
+      - AIRBYTE_ROLE=${AIRBYTE_ROLE:-}
+      - AIRBYTE_VERSION=${VERSION}
+      - API_URL=${API_URL:-}
+      - IS_DEMO=${IS_DEMO:-}
+      - PAPERCUPS_STORYTIME=${PAPERCUPS_STORYTIME:-}
+      - FULLSTORY=${FULLSTORY:-}
+      - OPENREPLAY=${OPENREPLAY:-}
+      - TRACKING_STRATEGY=${TRACKING_STRATEGY}
+      - INTERNAL_API_HOST=${INTERNAL_API_HOST}
+    depends_on:
+      - chaosgenius-fluentd
+  airbyte-temporal:
+    image: temporalio/auto-setup:1.7.0
+    logging: *default-logging
+    container_name: airbyte-temporal
+    restart: unless-stopped
+    ports:
+      - 7233:7233
+    environment:
+      - DB=postgresql
+      - DB_PORT=${DATABASE_PORT}
+      - POSTGRES_USER=${DATABASE_USER}
+      - POSTGRES_PWD=${DATABASE_PASSWORD}
+      - POSTGRES_SEEDS=${DATABASE_HOST}
+      - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
+      - LOG_LEVEL=${LOG_LEVEL}
+    volumes:
+      - ./temporal/dynamicconfig:/etc/temporal/config/dynamicconfig
+    depends_on:
+      - chaosgenius-fluentd
+
+volumes:
+  workspace:
+    name: ${WORKSPACE_DOCKER_MOUNT}
+  data:
+    name: ${DATA_DOCKER_MOUNT}
+  db:
+    name: ${DB_DOCKER_MOUNT}
+  cg-db:
+    name: ${CG_DB_DOCKER_MOUNT}

--- a/setup/fluentd/log.conf
+++ b/setup/fluentd/log.conf
@@ -1,0 +1,21 @@
+<source>
+  @type forward
+</source>
+
+<match *>
+  @type file
+  path /var/log/fluent/${container_name}/log_%Y%m%d_%H%M
+  append true
+
+  <buffer time, container_name>
+    @type file
+    path /var/log/fluent/buffer/
+    timekey      10m
+    timekey_wait 1m
+    flush_at_shutdown true
+  </buffer>
+
+  <format>
+    @type json
+  </format>
+</match>


### PR DESCRIPTION
 - all containers (except `fluentd` and `chaosgenius-init`) use the new fluentd logger
 - fluentd itself is a service in the docker compose
 - logs are stored in a local `logs/` directory
     - a separate directory is created for each container
     - logs are initially stored in the `buffer` directory before being flushed to the actual log directory - every ~10 mins
     - see `setup/fluentd/log.conf` for more details
 - **Caveats**:
     - fluentd itself does not perform any log rotation, so there is no bound on the size or number of log files
     - if the fluentd container does not start successfully, it leads to the other containers hanging. This is a bug in the fluentd driver.
        - Refer: https://github.com/moby/moby/issues/40063
        - The only solution we have found to this is to stop the docker service and manually delete these containers in `/var/run/docker/containers` and `/var/run/docker/containerd`

Co-authored-by: Bhargav <bhargavskumar51703@gmail.com>