### PR TITLE
feat(task-monitor): add configurable limit to no. of checkpoints shown

### DIFF
--- a/.env
+++ b/.env
@@ -30,6 +30,9 @@ CG_DB_DOCKER_MOUNT=cg_db
 # Caching timeout for APIs
 CACHE_DEFAULT_TIMEOUT=1
 
+# Number of last checkpoints to retrieve in Task Monitor
+TASK_CHECKPOINT_LIMIT=1000
+
 # === airbyte env vars start here ===
 VERSION=0.29.12-alpha
 

--- a/chaos_genius/controllers/task_monitor.py
+++ b/chaos_genius/controllers/task_monitor.py
@@ -8,6 +8,7 @@ from sqlalchemy import func
 from chaos_genius.databases.models.kpi_model import Kpi
 from chaos_genius.databases.models.task_model import Task
 from chaos_genius.extensions import db
+from chaos_genius.settings import TASK_CHECKPOINT_LIMIT
 
 
 def checkpoint_initial(
@@ -128,9 +129,17 @@ def get_checkpoints(sort_by_task_id=True, kpi_info=True, track_subtasks=True) ->
         track_subtasks (bool): whether to include completed_subtasks and total_subtasks in the Tasks (default: True)
     """
     if sort_by_task_id:
-        tasks: List[Task] = Task.query.order_by(Task.task_id.desc(), Task.timestamp.desc()).all()
+        tasks: List[Task] = (
+            Task.query.order_by(Task.task_id.desc(), Task.timestamp.desc())
+            .limit(TASK_CHECKPOINT_LIMIT)
+            .all()
+        )
     else:
-        tasks: List[Task] = Task.query.order_by(Task.timestamp.desc()).all()
+        tasks: List[Task] = (
+            Task.query.order_by(Task.timestamp.desc())
+            .limit(TASK_CHECKPOINT_LIMIT)
+            .all()
+        )
 
     if kpi_info:
         subtasks_cache = {}

--- a/chaos_genius/settings.py
+++ b/chaos_genius/settings.py
@@ -67,3 +67,6 @@ if IN_DOCKER == 'True':
     IN_DOCKER = True
 else:
     IN_DOCKER = False
+
+TASK_CHECKPOINT_LIMIT: int = int(os.getenv("TASK_CHECKPOINT_LIMIT", 1000))
+"""Number of last checkpoints to retrieve in Task Monitor"""


### PR DESCRIPTION
 - `TASK_CHECKPOINT_LIMIT` is used to limit the number of latest checkpoints shown in the task monitor
 - added it to `.env` and `settings.py`
 - tested
    - with values 10, 300, 1000
    - when not set - default value is 1000
    - when set to empty string or invalid string - error during startup because a number is needed