### PR TITLE
fix: do not checkpoint failure if no alerts are setup

### DIFF
--- a/chaos_genius/alerts/base_alerts.py
+++ b/chaos_genius/alerts/base_alerts.py
@@ -3,7 +3,7 @@ import os
 import io
 import json
 import pickle
-from typing import Optional, List
+from typing import Optional, List, Tuple
 import pandas as pd
 import datetime
 from datetime import date
@@ -409,7 +409,7 @@ def check_and_trigger_alert(alert_id):
     return True
 
 
-def trigger_anomaly_alerts_for_kpi(kpi_obj: Kpi, end_date: date) -> List[int]:
+def trigger_anomaly_alerts_for_kpi(kpi_obj: Kpi, end_date: date) -> Tuple[List[int], List[int]]:
     """Triggers anomaly alerts starting from end_date.
 
     Args:
@@ -418,8 +418,10 @@ def trigger_anomaly_alerts_for_kpi(kpi_obj: Kpi, end_date: date) -> List[int]:
 
     Returns:
         List[int]: List of alert IDs for which alert messages were successfully sent
+        List[int]: List of alert IDs for which alert failed
     """
     success_alerts = []
+    errors = []
     alerts = Alert.query.filter(
                             Alert.kpi == kpi_obj.id,
                             Alert.active == True,
@@ -432,4 +434,5 @@ def trigger_anomaly_alerts_for_kpi(kpi_obj: Kpi, end_date: date) -> List[int]:
             success_alerts.append(alert.id)
         except Exception as e:
             logger.error(f"Error running alert for Alert ID: {alert.id}", exc_info=e)
-    return success_alerts
+            errors.append(alert.id)
+    return success_alerts, errors

--- a/chaos_genius/jobs/anomaly_tasks.py
+++ b/chaos_genius/jobs/anomaly_tasks.py
@@ -94,8 +94,8 @@ def anomaly_single_kpi(kpi_id, end_date=None):
             # for last day.
             # TODO: Add this timedelta variable in some constant file in core
             updated_time = anomaly_end_date - timedelta(days=1)
-            alert_ids = trigger_anomaly_alerts_for_kpi(kpi, updated_time)
-            if alert_ids:
+            _, errors = trigger_anomaly_alerts_for_kpi(kpi, updated_time)
+            if not errors:
                 logger.info(f"Triggered the alerts for KPI {kpi_id}.")
                 _checkpoint_success("Alert trigger")
             else:


### PR DESCRIPTION
Simpler solution for #483 

 - returns errored alert IDs in trigger_anomaly_alerts_for_kpi
 - check error list instead of success list