### PR TITLE
fix: fixes nan output in deepdrills for specific case

### DIFF
--- a/chaos_genius/core/rca/root_cause_analysis.py
+++ b/chaos_genius/core/rca/root_cause_analysis.py
@@ -360,6 +360,8 @@ class RootCauseAnalysis:
 
         d1_agg = self._grp1_df[self._metric].agg(self._agg)
         d2_agg = self._grp2_df[self._metric].agg(self._agg)
+        d1_agg = 0 if pd.isna(d1_agg) else d1_agg
+        d2_agg = 0 if pd.isna(d2_agg) else d2_agg
         impact = d2_agg - d1_agg
         non_overlap_impact = df_subgroups["impact_non_overlap"].sum()
 


### PR DESCRIPTION
In DeepDrills, if one group has 0 rows and the aggregation is mean, we can get nan values in the output. This should fix that.