### PR TITLE
chore: update flake8, isort and dockerignore configs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 frontend
 .env
 docker
+.venv

--- a/.flake8
+++ b/.flake8
@@ -8,3 +8,4 @@ exclude =
     frontend,
     sandbox
 max-complexity = 10
+docstring-convention = google

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+profile=black


### PR DESCRIPTION
- Add `isort` config to honor black's formatting
- Add Google docstring convention to flake8 config
- Add `.venv` to dockerignore since built images do not need this (during build, dependencies are installed globally)