### PR TITLE
fix(task-monitor): make error modal bigger and anchor to top

### DIFF
--- a/chaos_genius/templates/status.html
+++ b/chaos_genius/templates/status.html
@@ -117,9 +117,6 @@
             -->
                 <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
 
-                <!-- This element is to trick the browser into centering the modal contents. -->
-                <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
-
                 <!--
               Modal panel, show/hide based on modal state.
 
@@ -130,7 +127,7 @@
                 From: "opacity-100 translate-y-0 sm:scale-100"
                 To: "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             -->
-                <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-4xl sm:w-full">
+                <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-4 sm:mx-4 box-border sm:align-middle sm:w-full" style="max-width: calc(100vw - 2rem);">
                     <div class="bg-white px-4 pt-5 pb-3 sm:p-6 sm:pb-3">
                         <div class="sm:flex sm:items-start">
                             <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
@@ -139,7 +136,7 @@
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                                 </svg>
                             </div>
-                            <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left overflow-x-auto">
+                            <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left overflow-x-auto sm:flex-grow">
                                 <div class="flex flex-row">
                                     <h3 style="flex-grow: 1;" class="self-center text-lg leading-6 font-medium text-gray-900" id="error-modal-title">
                                     </h3>
@@ -153,7 +150,7 @@
                                     <p class="text-sm text-gray-500" id="error-modal-message">
                                         Traceback for the error:
                                     </p>
-                                    <div style="max-height: 50vh;" class="overflow-x-auto rounded-md font-light" id="error-modal-traceback"></div>
+                                    <div style="text-align: left;" class="overflow-x-auto rounded-md font-light sm:text-left" id="error-modal-traceback"></div>
                                 </div>
                             </div>
                         </div>
@@ -243,6 +240,17 @@
             document.getElementById("error-modal").classList.add("hidden");
         }
     </script>
+    <style type="text/css">
+        #error-modal-traceback {
+            max-height: calc(100vh - 18rem);
+        }
+
+        @media (min-width: 640px) {
+            #error-modal-traceback {
+                max-height: calc(100vh - 12rem);
+            }
+        }
+    </style>
 </body>
 
 </html>


### PR DESCRIPTION
## Changes

- Made width of modal full view width (minus the margin)
- Made max height the full view heigh (minus margins)
- Instead of vertically centering the modal, anchor it to the top

## Screenshots

Large traceback:
![image](https://user-images.githubusercontent.com/34161949/147472599-b479ce65-151f-4f63-8e37-e3a1a6fc9d17.png)

Small traceback:
![image](https://user-images.githubusercontent.com/34161949/147472615-7884fe70-a17a-45d1-99bb-ff03b26222a2.png)
