### PR TITLE
Include dashboard list in KPI Info API

### DIFF
--- a/chaos_genius/views/kpi_view.py
+++ b/chaos_genius/views/kpi_view.py
@@ -346,7 +346,7 @@ def get_kpi_info(kpi_id):
         dashboard_id_list = [mapper.dashboard for mapper in mapper_obj_list]
         dashboard_list = get_dashboard_list_by_ids(dashboard_id_list)
         dashboard_list = [dashboard.as_dict for dashboard in dashboard_list]
-        data["dashboard_list"] = dashboard_list
+        data["dashboards"] = dashboard_list
         status = "success"
     except Exception as err:
         status = "failure"


### PR DESCRIPTION
Added code in `host/api/kpi/<int: kpi-id>` API to include the list of dashboards the kpi is present in.