### PR TITLE
fix: remove hardcoded snowflake connector ID

### DIFF
--- a/chaos_genius/third_party/integration_client.py
+++ b/chaos_genius/third_party/integration_client.py
@@ -86,8 +86,6 @@ class ThirdPartyClient(object):
         self.destination_conf = conf
 
     def check_sources_availability(self, sources_list):
-        # TODO: hardcode the snowflake, remove this
-        sources_list += [{"sourceDefinitionId": "e2d65910-8c8b-40a1-ae7d-ee2416b2bfa2"}]
         for source in sources_list:
                 source_specs = self.get_source_def_specs(source["sourceDefinitionId"])
                 try:


### PR DESCRIPTION
## Changes

Airbyte's Snowflake connector ID was being manually inserted into the sources_list to ensure it appears in the dropdown. This isn't needed anymore.