### PR TITLE
fix(task-monitor): ignore non-existent KPIs in checkpoints

### DIFF
--- a/chaos_genius/controllers/task_monitor.py
+++ b/chaos_genius/controllers/task_monitor.py
@@ -1,7 +1,7 @@
 """Utilities for logging and monitoring tasks."""
 
 import traceback
-from typing import List, Optional, cast
+from typing import List, Optional
 
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
@@ -168,11 +168,21 @@ def get_checkpoints(
             .all()
         )
 
+    valid_tasks = tasks
+
     if kpi_info:
         subtasks_cache = {}
         total_tasks_cache = {}
+
+        valid_tasks: List[Task] = []
+
         for task in tasks:
-            kpi = cast(Kpi, Kpi.get_by_id(task.kpi_id))
+            kpi: Kpi | None = Kpi.get_by_id(task.kpi_id)
+
+            if kpi is None:
+                continue
+
+            valid_tasks.append(task)
 
             task.kpi_name = kpi.name
 
@@ -214,4 +224,4 @@ def get_checkpoints(
                 subtasks_cache[task.task_id][0] += 1
                 task.total_subtasks = total_tasks_cache[key]
 
-    return tasks
+    return valid_tasks


### PR DESCRIPTION
## The issue

The task monitor was failing with an internal server error because it was trying to retrieve data for a KPI which was deleted.

## Changes

Modified the `get_checkpoints` function to fix this.

For any KPI ID for which `Kpi.get_by_id` returns None, we ignore that task. A list of valid tasks is returned which only has checkpoints of KPIs which exist.
Note: this is only done when `kpi_info` is enabled, otherwise the raw list of tasks is returned.