### PR TITLE
Redirect user to anomaly data for a KPI

### DIFF
--- a/chaos_genius/alerts/slack.py
+++ b/chaos_genius/alerts/slack.py
@@ -81,7 +81,7 @@ def anomaly_alert_slack(kpi_name, alert_name, kpi_id, alert_message, points, ove
                             "type": "plain_text",
                             "text": "View KPI"
                         },
-                        "url": f"{webapp_url_prefix()}#/dashboard/0/deepdrills/{kpi_id}",
+                        "url": f"{webapp_url_prefix()}#/dashboard/0/anomaly/{kpi_id}",
                         "action_id": "kpi_link",
                         "style": "primary",
                     },


### PR DESCRIPTION
- Earlier, the deepdrills data was displayed when
  user clicked on View KPI

- Now, anomaly data is visible when user clicks
  on View KPI button