### PR TITLE
fix(alert-digest): suffix _digest when retrieving config setting

### DIFF
--- a/chaos_genius/alerts/base_alert_digests.py
+++ b/chaos_genius/alerts/base_alert_digests.py
@@ -196,7 +196,7 @@ def check_and_trigger_digest(frequency: str):
 
     digest_config_settings: dict = digest_config.config_setting
 
-    if not digest_config_settings.get(frequency):
+    if not digest_config_settings.get(ALERT_ATTRIBUTES_MAPPER[frequency]):
         msg = f"Digests with frequency {frequency} have not been enabled."
         logger.info(msg)
         raise Exception(msg)


### PR DESCRIPTION
The digest config setting keys are named daily_digest and weekly_digest instead of daily and weekly.

Digests were failing due to this.