### PR TITLE
feat(dev): add script to run auto-reloading celery workers

### DIFF
--- a/dev_workers.sh
+++ b/dev_workers.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+source .venv/bin/activate
+
+(trap 'kill 0' SIGINT EXIT; \
+./scripts/celery/dev_scheduler.sh & \
+./scripts/celery/dev_worker-analytics.sh & \
+./scripts/celery/dev_worker-alerts.sh )

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,3 +17,7 @@ flake8-docstrings==1.6.0
 flake8-isort==4.0.0
 isort==5.8.0
 pep8-naming==0.11.1
+
+# for auto-reloading celery workers when code changes
+watchdog[watchmedo]~=2.1.6
+

--- a/scripts/celery/dev_scheduler.sh
+++ b/scripts/celery/dev_scheduler.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- celery -A run.celery beat --loglevel=DEBUG

--- a/scripts/celery/dev_worker-alerts.sh
+++ b/scripts/celery/dev_worker-alerts.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- celery -A run.celery worker --loglevel=INFO --concurrency=2 -P processes -Q alerts

--- a/scripts/celery/dev_worker-analytics.sh
+++ b/scripts/celery/dev_worker-analytics.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- celery -A run.celery worker --loglevel=INFO --concurrency=2 -P processes -Q anomaly-rca


### PR DESCRIPTION
The single script starts celery scheduler, analytics worker and alerts
worker. It also stops all 3 of them on doing ctrl-c.

Added a new dependency `watchdog` to watch files and restart workers
when there's a code change.

TODO: have a flag to disable auto-reload.