### PR TITLE
fix: Add resolver in nginx-default.conf

### DIFF
--- a/frontend/nginx/nginx-default.conf
+++ b/frontend/nginx/nginx-default.conf
@@ -16,8 +16,10 @@ server {
     }
 
     location /api/ {
+        resolver 127.0.0.11 valid=30s;
+        set chaosgenius_server chaosgenius-server;
         proxy_read_timeout 1h;
-        proxy_pass http://chaosgenius-server:5000;
+        proxy_pass http://$chaosgenius_server:5000;
         proxy_set_header Host $http_host;
     }
 


### PR DESCRIPTION
Added resolver in the location level and set it to docker's DNS Server
address.

Used a variable to reference the chaosgenius-server address for proxy_pass.

Done to ensure webapp starts up even if chaosgenius-server fails to start.