### PR TITLE
fix(thirdparty): use internal ports for airbyte communication

### DIFF
--- a/.env
+++ b/.env
@@ -10,18 +10,18 @@ FLASK_DEBUG=0
 FLASK_RUN_PORT=5000
 SECRET_KEY="t8GIEp8hWmR8y6VLqd6qQCMXzjRaKsx8nRruWNtFuec="
 SEND_FILE_MAX_AGE_DEFAULT=31556926
-DB_HOST=localhost
+DB_HOST=chaosgenius-db
 DB_USERNAME=postgres
 DB_PASSWORD=chaosgenius
-DB_PORT=5433
+DB_PORT=5432
 META_DATABASE=chaosgenius
 DATA_DATABASE=chaosgenius_data
 DATABASE_URL_CG_DB=postgresql+psycopg2://postgres:chaosgenius@chaosgenius-db/chaosgenius
 INTEGRATION_SERVER=http://server:8001
-INTEGRATION_DB_HOST=localhost
+INTEGRATION_DB_HOST=chaosgenius-db
 INTEGRATION_DB_USERNAME=postgres
 INTEGRATION_DB_PASSWORD=chaosgenius
-INTEGRATION_DB_PORT=5433
+INTEGRATION_DB_PORT=5432
 INTEGRATION_DATABASE=chaosgenius_data
 CELERY_RESULT_BACKEND=redis://chaosgenius-redis:6379/1
 CELERY_BROKER_URL=redis://chaosgenius-redis:6379/1
@@ -69,6 +69,9 @@ DATABASE_PORT=5432
 DATABASE_DB=airbyte
 # translate manually DATABASE_URL=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT/${DATABASE_DB}
 DATABASE_URL=jdbc:postgresql://db:5432/airbyte
+
+# airbyte network - use the default network created by docker-compose for CG
+DOCKER_NETWORK=chaos_genius_default
 
 # Airbyte Internal Config Database, default to reuse the Job Database when they are empty
 # Usually you do not need to set them; they are explicitly left empty to mute docker compose warnings

--- a/docker-compose.thirdparty.yml
+++ b/docker-compose.thirdparty.yml
@@ -123,6 +123,8 @@ services:
     volumes:
       - ./docker/cg-db-setup:/docker-entrypoint-initdb.d/
       - cg-db:/var/lib/postgresql/data
+    ports:
+      - "5433:5432"
 
   chaosgenius-redis:
     container_name: chaosgenius-redis
@@ -273,6 +275,7 @@ services:
     environment:
       - POSTGRES_USER=${DATABASE_USER}
       - POSTGRES_PASSWORD=${DATABASE_PASSWORD}
+      - DOCKER_NETWORK=${DOCKER_NETWORK}
     volumes:
       - db:/var/lib/postgresql/data
   scheduler:
@@ -311,6 +314,7 @@ services:
       - RESOURCE_MEMORY_LIMIT=${RESOURCE_MEMORY_LIMIT}
       - MAX_SYNC_JOB_ATTEMPTS=${MAX_SYNC_JOB_ATTEMPTS}
       - MAX_SYNC_TIMEOUT_DAYS=${MAX_SYNC_TIMEOUT_DAYS}
+      - DOCKER_NETWORK=${DOCKER_NETWORK}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - workspace:${WORKSPACE_ROOT}
@@ -346,6 +350,7 @@ services:
       - RESOURCE_CPU_LIMIT=${RESOURCE_CPU_LIMIT}
       - RESOURCE_MEMORY_REQUEST=${RESOURCE_MEMORY_REQUEST}
       - RESOURCE_MEMORY_LIMIT=${RESOURCE_MEMORY_LIMIT}
+      - DOCKER_NETWORK=${DOCKER_NETWORK}
     volumes:
       - workspace:${WORKSPACE_ROOT}
       - data:${CONFIG_ROOT}
@@ -365,6 +370,7 @@ services:
       - OPENREPLAY=${OPENREPLAY:-}
       - TRACKING_STRATEGY=${TRACKING_STRATEGY}
       - INTERNAL_API_HOST=${INTERNAL_API_HOST}
+      - DOCKER_NETWORK=${DOCKER_NETWORK}
   airbyte-temporal:
     image: temporalio/auto-setup:1.7.0
     logging: *default-logging
@@ -378,6 +384,7 @@ services:
       - POSTGRES_SEEDS=${DATABASE_HOST}
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
       - LOG_LEVEL=${LOG_LEVEL}
+      - DOCKER_NETWORK=${DOCKER_NETWORK}
     volumes:
       - ./temporal/dynamicconfig:/etc/temporal/config/dynamicconfig
 
@@ -390,3 +397,7 @@ volumes:
     name: ${DB_DOCKER_MOUNT}
   cg-db:
     name: ${CG_DB_DOCKER_MOUNT}
+
+networks:
+  default:
+    name: chaos_genius_default


### PR DESCRIPTION
Fixes #720 

Communication with airbyte was being done through the host interface and
relied on the chaosgenius-db being opened on port 5433.

Fixed this by:
- Using `chaosgenius-db` as hostname and port 5432 as the CG DB
  configuration given to airbyte.
- Make airbyte use the internal network created by docker compose
  instead of the host network
    - https://github.com/airbytehq/airbyte/issues/9468#issuecomment-1012204786
    - This is done using the `DOCKER_NETWORK` env var
    - Also made sure the name of the network created by docker-compose
      is `chaos_genius_default`, which is the same as the default name
      created by compose. Added this to ensure it does not break in the
      future.
- Opened port 5433 for chaosgenius-db to support older airbyte data
  sources.