### PR TITLE
feat: set default value for CHAOSGENIUS_WEBAPP_URL

### DIFF
--- a/.env
+++ b/.env
@@ -25,7 +25,7 @@ INTEGRATION_DB_PORT=5432
 INTEGRATION_DATABASE=chaosgenius_data
 CELERY_RESULT_BACKEND=redis://chaosgenius-redis:6379/1
 CELERY_BROKER_URL=redis://chaosgenius-redis:6379/1
-CHAOSGENIUS_WEBAPP_URL=
+CHAOSGENIUS_WEBAPP_URL=http://localhost:8080/
 
 # Alert configuration
 ## to enable event alerts


### PR DESCRIPTION
- CHAOSGENIUS_WEBAPP_URL is now set to http://localhost:8080/
  by default in the .env file