### PR TITLE
feat(anomaly-params): allow hourly scheduler_frequency

### DIFF
--- a/chaos_genius/views/anomaly_data_view.py
+++ b/chaos_genius/views/anomaly_data_view.py
@@ -627,6 +627,10 @@ ANOMALY_PARAMS_META = {
                     "value": "D",
                     "name": "Daily",
                 },
+                {
+                    "value": "H",
+                    "name": "Hourly",
+                },
             ],
         },
     ],
@@ -748,7 +752,7 @@ def validate_partial_anomaly_params(
         frequency = anomaly_params["scheduler_frequency"]
 
         err, anomaly_params = validate_frequency(
-            frequency, "scheduler_frequency", {"D"}
+            frequency, "scheduler_frequency", {"D", "H"}
         )
 
         if err != "":


### PR DESCRIPTION
Changed the anomaly params API to accept hourly scheduler frequency. "H" is the value stored in `scheduler_params`.

This also enables the option in frontend as it is sent through `ANOMALY_PARAMS_META` and will be shown as "Hourly" to the user.