### PR TITLE
 fix(kpi-validation): skip tz-naive check only for druid and update tests

### DIFF
--- a/chaos_genius/core/utils/kpi_validation.py
+++ b/chaos_genius/core/utils/kpi_validation.py
@@ -8,7 +8,6 @@ from pandas.api.types import is_datetime64_any_dtype as is_datetime
 
 from chaos_genius.core.rca.root_cause_analysis import SUPPORTED_AGGREGATIONS
 from chaos_genius.core.utils.data_loader import DataLoader
-from chaos_genius.databases.models.data_source_model import DataSource
 from chaos_genius.settings import MAX_ROWS_FOR_DEEPDRILLS
 
 KPI_VALIDATION_TAIL_SIZE = 1000
@@ -16,11 +15,13 @@ KPI_VALIDATION_TAIL_SIZE = 1000
 logger = logging.getLogger(__name__)
 
 
-def validate_kpi(kpi_info: Dict[str, Any], datasource: DataSource) -> Tuple[bool, str]:
+def validate_kpi(kpi_info: Dict[str, Any], data_source: Dict[str, Any]) -> Tuple[bool, str]:
     """Load data for KPI and invoke all validation checks.
 
     :param kpi_info: Dictionary with all params for the KPI
     :type kpi_info: Dict[str, Any]
+    :param data_source: Dictionary describing the data source
+    :type data_source: Dict[str, Any]
     :return: Returns a tuple with the status as a bool and a status message
     :rtype: Tuple[bool, str]
     """
@@ -33,7 +34,7 @@ def validate_kpi(kpi_info: Dict[str, Any], datasource: DataSource) -> Tuple[bool
         logger.error("Unable to load data for KPI validation", exc_info=1)
         return False, "Could not load data. Error: " + str(e)
 
-    supports_tz_aware = datasource.connection_type == "Druid"
+    supports_tz_aware = data_source["connection_type"] == "Druid"
 
     return _validate_kpi_from_df(
         df,

--- a/chaos_genius/core/utils/kpi_validation.py
+++ b/chaos_genius/core/utils/kpi_validation.py
@@ -8,6 +8,7 @@ from pandas.api.types import is_datetime64_any_dtype as is_datetime
 
 from chaos_genius.core.rca.root_cause_analysis import SUPPORTED_AGGREGATIONS
 from chaos_genius.core.utils.data_loader import DataLoader
+from chaos_genius.databases.models.data_source_model import DataSource
 from chaos_genius.settings import MAX_ROWS_FOR_DEEPDRILLS
 
 KPI_VALIDATION_TAIL_SIZE = 1000
@@ -15,7 +16,7 @@ KPI_VALIDATION_TAIL_SIZE = 1000
 logger = logging.getLogger(__name__)
 
 
-def validate_kpi(kpi_info: Dict[str, Any]) -> Tuple[bool, str]:
+def validate_kpi(kpi_info: Dict[str, Any], datasource: DataSource) -> Tuple[bool, str]:
     """Load data for KPI and invoke all validation checks.
 
     :param kpi_info: Dictionary with all params for the KPI
@@ -32,12 +33,15 @@ def validate_kpi(kpi_info: Dict[str, Any]) -> Tuple[bool, str]:
         logger.error("Unable to load data for KPI validation", exc_info=1)
         return False, "Could not load data. Error: " + str(e)
 
+    supports_tz_aware = datasource.connection_type == "Druid"
+
     return _validate_kpi_from_df(
         df,
         kpi_info,
         kpi_column_name=kpi_info["metric"],
         agg_type=kpi_info["aggregation"],
         date_column_name=kpi_info["datetime_column"],
+        supports_tz_aware=supports_tz_aware,
     )
 
 
@@ -48,6 +52,7 @@ def _validate_kpi_from_df(
     agg_type: str,
     date_column_name: str,
     debug: bool = False,
+    supports_tz_aware: bool = False,
 ) -> Tuple[bool, str]:
     """Invoke each validation check and break if there's a falsy check.
 
@@ -108,8 +113,14 @@ def _validate_kpi_from_df(
         {
             "debug_str": "Check #4: Validate date column is parseable",
             "status": lambda: _validate_date_column_is_parseable(
-                df, date_column_name=date_column_name
+                df, date_column_name=date_column_name, supports_tz_aware=supports_tz_aware
             ),
+        },
+        {
+            "debug_str": "Check #5: Validate date column is tz-naive if tz-aware not supported",
+            "status": lambda: _validate_date_column_is_tz_naive(
+                df, date_column_name=date_column_name
+            ) if not supports_tz_aware else (True, "Accepted!"),
         },
         {
             "debug_str": "Check #6: Validate dimensions",
@@ -226,6 +237,7 @@ def _validate_kpi_not_datetime(
 def _validate_date_column_is_parseable(
     df: pd.core.frame.DataFrame,
     date_column_name: str,
+    supports_tz_aware: bool,
 ) -> Tuple[bool, str]:
     """Validate if specified date column is parseable.
 
@@ -237,11 +249,44 @@ def _validate_date_column_is_parseable(
     :rtype: Tuple[bool, str]
     """
     # has to be datetime only then proceed else exit
-    parsed_df = pd.to_datetime(df[date_column_name], errors="ignore")
-    if not is_datetime(parsed_df):
+    if supports_tz_aware:
+        # try to parse date col
+        # TODO: ensure this parses only tz-aware data and nothing else
+        #       (str, int, float, etc.)
+        date_col = pd.to_datetime(df[date_column_name], errors="ignore")
+    else:
+        # support only datetime type (not datetime with tz, strings, etc.)
+        date_col = df[date_column_name]
+
+    if not is_datetime(date_col):
         invalid_type_err_msg = (
             "The datetime column is of the type"
             f" {df[date_column_name].dtype}, use 'cast' to convert to datetime."
+        )
+        return False, invalid_type_err_msg
+
+    return True, "Accepted!"
+
+
+def _validate_date_column_is_tz_naive(
+    df: pd.core.frame.DataFrame,
+    date_column_name: str,
+) -> Tuple[bool, str]:
+    """Validate if specified date column is tz-naive.
+
+    :param df: A pandas DataFrame
+    :type df: pd.core.frame.DataFrame
+    :param date_column_name: Name of the date column
+    :type date_column_name: str
+    :return: returns a tuple with the status as a bool and a status message
+    :rtype: Tuple[bool, str]
+    """
+    date_col = df[date_column_name]
+    all_tz_naive = date_col.apply(lambda t: t.tz is None).all()
+    if not all_tz_naive:
+        invalid_type_err_msg = (
+            "The datetime column has timezone aware data,"
+            " use 'cast' to convert to timezone naive."
         )
         return False, invalid_type_err_msg
 

--- a/chaos_genius/views/kpi_view.py
+++ b/chaos_genius/views/kpi_view.py
@@ -96,7 +96,7 @@ def kpi():
             timezone_aware=timezone_aware,
         )
         # Perform KPI Validation
-        status, message = validate_kpi(new_kpi.as_dict)
+        status, message = validate_kpi(new_kpi.as_dict, data_source)
         if status is not True:
             return jsonify(
                 {"error": message, "status": "failure", "is_critical": "true"}

--- a/chaos_genius/views/kpi_view.py
+++ b/chaos_genius/views/kpi_view.py
@@ -69,16 +69,9 @@ def kpi():
             if data["kpi_query"][-1] == ";":
                 data["kpi_query"] = data["kpi_query"][:-1]
 
-            date_col = data_con.run_query(
-                f"select {data['datetime_column']} from ({data['kpi_query']}) {randomword(10)} limit 1"
-            )[data["datetime_column"]]
-        else:
-            date_col = data_con.run_query(
-                f"select {data['datetime_column']} from {data['table_name']} limit 1"
-            )[data["datetime_column"]]
-
-        date_col = pd.to_datetime(date_col)
-        timezone_aware = date_col[0].tz is not None
+        # TODO: make this more general.
+        #       query data to figure out if it's tz-aware.
+        timezone_aware = data_source["connection_type"] == "Druid"
 
         new_kpi = Kpi(
             name=data.get("name"),

--- a/tests/features/kpi_validation.feature
+++ b/tests/features/kpi_validation.feature
@@ -83,7 +83,8 @@ Feature: KPI Validation
     Scenario: date/time column is a date string
         Given a newly added KPI and its DataFrame
         When the date/time column is a date string
-        Then validation should pass
+        Then validation should fail
+        And error message should be "The datetime column is of the type object, use 'cast' to convert to datetime."
 
     Scenario: date/time column is some categorical string
         Given a newly added KPI and its DataFrame
@@ -114,10 +115,18 @@ Feature: KPI Validation
     Scenario: date/time column is timezone-aware
         Given a newly added KPI and its DataFrame
         When date/time column is a timezone-aware timestamp
+        Then validation should fail
+        And error message should be "The datetime column has timezone aware data, use 'cast' to convert to timezone naive."
+
+    Scenario: date/time column is timezone-aware for a Druid KPI
+        Given a newly added KPI and its DataFrame
+        When the KPI is from a Druid data source
+        When date/time column is a timezone-aware timestamp
         Then validation should pass
 
     # ISO 8601 datetime string with timezone
     Scenario: date/time column is timezone-aware but in string format
         Given a newly added KPI and its DataFrame
         When date/time column is a timezone-aware timestamp but in string format
-        Then validation should pass
+        Then validation should fail
+        And error message should be "The datetime column is of the type object, use 'cast' to convert to datetime."

--- a/tests/features/kpi_validation.feature
+++ b/tests/features/kpi_validation.feature
@@ -79,6 +79,12 @@ Feature: KPI Validation
         Then validation should fail
         And error message should be "The datetime column is of the type float64, use 'cast' to convert to datetime."
 
+    # ISO 8601 date string
+    Scenario: date/time column is a date string
+        Given a newly added KPI and its DataFrame
+        When the date/time column is a date string
+        Then validation should pass
+
     Scenario: date/time column is some categorical string
         Given a newly added KPI and its DataFrame
         When the date/time column is a categorical string
@@ -104,3 +110,14 @@ Feature: KPI Validation
         When date/time column has integer unix timestamp
         Then validation should fail
         And error message should be "The datetime column is of the type int64, use 'cast' to convert to datetime."
+
+    Scenario: date/time column is timezone-aware
+        Given a newly added KPI and its DataFrame
+        When date/time column is a timezone-aware timestamp
+        Then validation should pass
+
+    # ISO 8601 datetime string with timezone
+    Scenario: date/time column is timezone-aware but in string format
+        Given a newly added KPI and its DataFrame
+        When date/time column is a timezone-aware timestamp but in string format
+        Then validation should pass

--- a/tests/test_kpi_validation.py
+++ b/tests/test_kpi_validation.py
@@ -42,6 +42,7 @@ def new_kpi_df():  # noqa: D103
         [
             [
                 "2021-12-21",
+                "2022-03-10T14:34:12+05:30",
                 1,
                 "a",
                 "q",
@@ -53,6 +54,7 @@ def new_kpi_df():  # noqa: D103
             ],
             [
                 "2021-12-22",
+                "2022-02-10T14:34:12+05:30",
                 2,
                 "b",
                 "w",
@@ -64,6 +66,7 @@ def new_kpi_df():  # noqa: D103
             ],
             [
                 "2021-12-23",
+                "2022-01-10T14:34:12+05:30",
                 3,
                 "c",
                 "e",
@@ -75,6 +78,7 @@ def new_kpi_df():  # noqa: D103
             ],
             [
                 "2021-12-24",
+                "2021-12-10T14:34:12+05:30",
                 4,
                 "d",
                 "r",
@@ -87,6 +91,7 @@ def new_kpi_df():  # noqa: D103
         ],
         columns=[
             "date_col",
+            "datetime_timezone_aware",
             "metric_col",
             "dim1",
             "dim2",
@@ -97,7 +102,12 @@ def new_kpi_df():  # noqa: D103
             "unix_time",
         ],
     )
+    # another col which is date but in string form
+    df["date_col_str"] = df["date_col"]
     df["date_col"] = pd.to_datetime(df["date_col"])
+    # another col which is tz-ware timestamp but in string form
+    df["datetime_timezone_aware_str"] = df["datetime_timezone_aware"]
+    df["datetime_timezone_aware"] = pd.to_datetime(df["datetime_timezone_aware"])
     return kpi, df
 
 
@@ -213,6 +223,13 @@ def test_date_col_is_float():  # noqa: D103
 
 
 @scenario(
+    "features/kpi_validation.feature", "date/time column is a date string"
+)
+def test_date_col_is_date_str():  # noqa: D103
+    pass
+
+
+@scenario(
     "features/kpi_validation.feature", "date/time column is some categorical string"
 )
 def test_date_col_is_cat():  # noqa: D103
@@ -240,6 +257,22 @@ def test_date_weird():  # noqa: D103
     "date/time column has unix timestamp",
 )
 def test_date_unix():  # noqa: D103
+    pass
+
+
+@scenario(
+    "features/kpi_validation.feature",
+    "date/time column is timezone-aware",
+)
+def test_datetime_timezone_aware():  # noqa: D103
+    pass
+
+
+@scenario(
+    "features/kpi_validation.feature",
+    "date/time column is timezone-aware but in string format",
+)
+def test_datetime_timezone_aware_str():  # noqa: D103
     pass
 
 
@@ -387,6 +420,18 @@ def date_col_is_float(new_kpi_df: Tuple[Kpi, pd.DataFrame], monkeypatch):  # noq
 
 
 @when(
+    "the date/time column is a date string",
+    target_fixture="new_kpi_df",
+)
+def date_col_is_date_str(new_kpi_df: Tuple[Kpi, pd.DataFrame], monkeypatch):  # noqa: D103
+    kpi, df = new_kpi_df
+
+    monkeypatch.setattr(kpi, "datetime_column", "date_col_str")
+
+    return kpi, df
+
+
+@when(
     "the date/time column is a categorical string",
     target_fixture="new_kpi_df",
 )
@@ -433,5 +478,37 @@ def date_unix(new_kpi_df: Tuple[Kpi, pd.DataFrame], monkeypatch):  # noqa: D103
     kpi, df = new_kpi_df
 
     monkeypatch.setattr(kpi, "datetime_column", "unix_time")
+
+    return kpi, df
+
+
+@when(
+    "date/time column is a timezone-aware timestamp",
+    target_fixture="new_kpi_df",
+)
+def datetime_timezone_aware(  # noqa: D103
+    new_kpi_df: Tuple[Kpi, pd.DataFrame], monkeypatch
+):
+    kpi: Kpi
+    df: pd.DataFrame
+    kpi, df = new_kpi_df
+
+    monkeypatch.setattr(kpi, "datetime_column", "datetime_timezone_aware")
+
+    return kpi, df
+
+
+@when(
+    "date/time column is a timezone-aware timestamp but in string format",
+    target_fixture="new_kpi_df",
+)
+def datetime_timezone_aware_str(  # noqa: D103
+    new_kpi_df: Tuple[Kpi, pd.DataFrame], monkeypatch
+):
+    kpi: Kpi
+    df: pd.DataFrame
+    kpi, df = new_kpi_df
+
+    monkeypatch.setattr(kpi, "datetime_column", "datetime_timezone_aware_str")
 
     return kpi, df


### PR DESCRIPTION
- `validate_kpi` now receives the DataSource object too
    - This can be used for datasource-specific behaviour
    - Currently, the KPI is assumed to support tz-aware if it's Druid
- Added back timezone-naive check
    - This is skipped only if tz-aware is supported (only Druid for now)
- Parsing of datetime column is only done in case of Druid
    - Note: this means, the datetime column check is very lax for Druid.
      It will accept string, int and floats too. Before this commit,
      this behaviour was added for other data sources too.
    - Other data sources continue the old behaviour
- Updated tests
    - added cases where datetime column is string or is timezone-aware
    - added test for Druid-specific KPI
        - timezone-aware is accepted in that case
        - had to add a new fixture - `extra_kpi_validation_data` to
          support this
    - also formatted test_kpi_validation