### PR TITLE
Setup Gitpod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -345,3 +345,7 @@ docs/yarn-error.log*
 ########### Third Party Integrations ##########
 .integrations.json
 .connectors
+
+########### Gitpod #########################
+
+dump.rdb

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -4,3 +4,7 @@ FROM gitpod/workspace-postgres
 RUN sudo apt-get update  && \
     sudo apt-get install -y redis-server && \
     sudo rm -rf /var/lib/apt/lists/*
+
+ENV PYTHONUSERBASE=/workspace/.pip-modules
+ENV PATH=$PYTHONUSERBASE/bin:$PATH
+ENV PIP_USER=yes

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,0 +1,6 @@
+FROM gitpod/workspace-postgres
+
+# Install Redis.
+RUN sudo apt-get update  && \
+    sudo apt-get install -y redis-server && \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.env
+++ b/.gitpod.env
@@ -1,0 +1,6 @@
+CHAOSGENIUS_WEBAPP_URL=CHAOSGENIUS_WEBAPP_URL_HERE
+
+DATABASE_URL_CG_DB=postgresql+psycopg2://gitpod@localhost/postgres
+
+CELERY_RESULT_BACKEND=redis://localhost:6379/1
+CELERY_BROKER_URL=redis://localhost:6379/1

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,6 +13,7 @@ tasks:
       sed -i "s~CHAOSGENIUS_WEBAPP_URL_HERE~`gp url 5000`~g" ".env.local"
       pg_start
       flask db upgrade
+      unset PGHOSTADDR
       bash dev_server.sh
 
   - name: Webapp

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,9 +7,7 @@ tasks:
   - name: API Server
     init: |
       pip install wheel
-      # required for prophet
-      pip install numpy pandas pystan==2.19.1.1
-      pip install -r requirements/dev.txt # runs during prebuild
+      pip install -r requirements/dev.txt
     command: |
       cp .gitpod.env .env.local
       sed -i "s~CHAOSGENIUS_WEBAPP_URL_HERE~`gp url 5000`~g" ".env.local"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,6 +11,8 @@ tasks:
       pip install numpy
       pip install -r requirements/dev.txt # runs during prebuild
     command: |
+      cp .gitpod.env .env.local
+      sed -i "s~CHAOSGENIUS_WEBAPP_URL_HERE~`gp url 5000`~g" ".env.local"
       pg_start
       flask db upgrade
       bash dev_server.sh

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,17 +3,36 @@ image:
 
 # List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
 tasks:
+  # modify .bashrc here.
+  # `PGHOSTADDR` is set to the Postgres server running on Gitpod. pyscopg2 picks up this
+  # variable and connects to that DB instead of the one we specify through data sources
+  # for some reason. So we unset this.
+  # See `DATABASE_URL_CG_DB` in `.gitpod.env` for the credentials to the Postgres server
+  # running inside Gitpod.
+  - before: printf 'unset PGHOSTADDR\n' >> $HOME/.bashrc && exit
 
+  # the backend server
   - name: API Server
     init: |
       pip install wheel
       pip install -r requirements/dev.txt
+      # notify that backend requirements have finished installing
+      gp sync-done backend-reqs
     command: |
       cp .gitpod.env .env.local
+      # get the URL for port 5000 exposed through Gitpod and use it as the WEBAPP_URL
+      # TODO: links to "View KPI", etc. won't work since they are on port 3000
       sed -i "s~CHAOSGENIUS_WEBAPP_URL_HERE~`gp url 5000`~g" ".env.local"
+
+      # start postgres server
       pg_start
+
+      # apply migrations
       flask db upgrade
-      unset PGHOSTADDR
+
+      # notify that backend has been setup completely
+      gp sync-done backend-setup
+
       bash dev_server.sh
 
   - name: Webapp
@@ -22,16 +41,26 @@ tasks:
       npm install
     command: |
       cd frontend
+      # BASE_URL is set to port 5000 exposed through gitpod
       REACT_APP_BASE_URL=`gp url 5000` npm start
 
   - name: Redis
     command: redis-server
 
-# List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
+  - name: Workers and Scheduler
+    # TODO: is the await needed here?
+    init: gp sync-await backend-reqs
+    command: |
+      # wait all of backend setup (incl. migrations, env vars) to be completed
+      gp sync-await backend-setup
+      bash dev_workers.sh
+
 ports:
+  # webapp
   - port: 3000
     onOpen: open-browser
     visibility: "public"
+  # backend server
   - port: 5000
     visibility: "public"
 
@@ -39,3 +68,10 @@ vscode:
   extensions:
     - "ms-python.python"
     - "samuelcolvin.jinjahtml"
+
+github:
+  prebuilds:
+    # add a check to pull requests (defaults to true)
+    addCheck: false
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,6 +7,8 @@ tasks:
   - name: API Server
     init: |
       pip install wheel
+      # required for prophet
+      pip install numpy
       pip install -r requirements/dev.txt # runs during prebuild
     command: |
       pg_start
@@ -19,7 +21,7 @@ tasks:
       npm install
     command: |
       cd frontend
-      REACT_APP_BASE_URL=http://localhost:5000 npm start
+      REACT_APP_BASE_URL=`gp url 5000` npm start
 
   - name: Redis
     command: redis-server
@@ -28,7 +30,9 @@ tasks:
 ports:
   - port: 3000
     onOpen: open-browser
+    visibility: "public"
   - port: 5000
+    visibility: "public"
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,9 @@
 tasks:
 
   - name: API Server
-    init: pip install -r requirements/dev.txt # runs during prebuild
+    init: |
+      pip install wheel
+      pip install -r requirements/dev.txt # runs during prebuild
     command: bash dev_server.sh
 
   - name: Webapp

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,22 @@
+# List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+
+  - name: API Server
+    init: pip install -r requirements/dev.txt # runs during prebuild
+    command: bash dev_server.sh
+
+  - name: Webapp
+    init: |
+      cd frontend
+      npm install
+    command: REACT_APP_BASE_URL=http://localhost:5000 npm start
+
+# List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
+ports:
+  - port: 3000
+    onOpen: open-preview
+  - port: 5000
+
+vscode:
+  extensions:
+    - "ms-python.python"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,7 +9,9 @@ tasks:
     init: |
       cd frontend
       npm install
-    command: REACT_APP_BASE_URL=http://localhost:5000 npm start
+    command: |
+      cd frontend
+      REACT_APP_BASE_URL=http://localhost:5000 npm start
 
 # List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
 ports:
@@ -20,3 +22,4 @@ ports:
 vscode:
   extensions:
     - "ms-python.python"
+    - "samuelcolvin.jinjahtml"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,7 +8,7 @@ tasks:
     init: |
       pip install wheel
       # required for prophet
-      pip install numpy
+      pip install numpy pandas pystan==2.19.1.1
       pip install -r requirements/dev.txt # runs during prebuild
     command: |
       cp .gitpod.env .env.local

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,6 @@
+image:
+  file: .gitpod.dockerfile
+
 # List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
 tasks:
 
@@ -5,7 +8,10 @@ tasks:
     init: |
       pip install wheel
       pip install -r requirements/dev.txt # runs during prebuild
-    command: bash dev_server.sh
+    command: |
+      pg_start
+      flask db upgrade
+      bash dev_server.sh
 
   - name: Webapp
     init: |
@@ -15,10 +21,13 @@ tasks:
       cd frontend
       REACT_APP_BASE_URL=http://localhost:5000 npm start
 
+  - name: Redis
+    command: redis-server
+
 # List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
 ports:
   - port: 3000
-    onOpen: open-preview
+    onOpen: open-browser
   - port: 5000
 
 vscode:


### PR DESCRIPTION
# Overview

Adds configuration for gitpod.

Services started:
- API Server (init part of this can take time due to prophet installation)
- Webapp (opens in a new tab)
- Redis
- Postgres DB (starts before API server)

The `.env` is setup correctly to work out of the box without additional changes.

Python and Jinja plugin are pre-installed in the workspace.

## Usage

(to use gitpod from this branch) visit https://gitpod.io/#https://github.com/chaos-genius/chaos_genius/tree/gitpod-setup.

You may need to login with GitHub and it takes 5-10mins for setup.

## Known issues

- Please wait for the API server to start up before changing branches (the message will be something like Debugger is active! Debugger PIN: 000-000-000).
    - This is needed because gitpod specific files are only present on that branch. Will not be needed once this PR is merged.
- The workspace shuts down after 30 mins in inactivity. After restarting, the API server won't work because pip packages get cleared. Run these commands in a new terminal to start the API server again (This is due to a bug in [gitpod](https://github.com/gitpod-io/gitpod/issues/7077)):
    ```bash
    pip install wheel
    pip install -r requirements/dev.txt
    pg_start
    flask db upgrade
    bash dev_server.sh
    ```
- Cannot connect to external DBs by default ([ref 1](https://community.gitpod.io/t/psql-remote-connection-not-working/1323/4))
    - In the terminal which runs "API Server", stop the server using ctrl-c and run
      ```bash
      unset PGHOSTADDR
      bash dev_server.sh
      ```
- Sending emails via SMTP does not work ([ref 1](https://community.gitpod.io/t/cant-send-emails-via-smtp/1727), [ref 2](https://github.com/gitpod-io/gitpod/issues/965))