### PR TITLE
chore(flake8): remove error ignores

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,5 @@
 [flake8]
 max-line-length = 88
-extend-ignore = E203, E501, D203
 exclude =
     .git,
     __pycache__,


### PR DESCRIPTION
# Changes

Removed ignores in flake8 config. It is a good idea to ignore errors which are hard/impossible to fix in our codebase, but these are very simple fixes.

- E501 is the line length error. Since we have an explicitly defined max line length limit (88 chars), it should be enforced using flake8.
- E203 is whitespace before a colon (https://www.flake8rules.com/rules/E203.html). There's no reason it should be disabled as it is very simple to fix.
- D203 is no blank line before class docstring (https://pep257.readthedocs.io/en/latest/error_codes.html). This too is a simple fix.