### PR TITLE
Post refactor alert fixes

### DIFF
--- a/chaos_genius/alerts/anomaly_alerts.py
+++ b/chaos_genius/alerts/anomaly_alerts.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from typing import Any, Dict, List, Optional, Sequence, Tuple, TypeVar, Union
 
 import pandas as pd
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, StrictFloat, StrictInt, root_validator, validator
 from pydantic.tools import parse_obj_as
 
 from chaos_genius.alerts.constants import (
@@ -122,7 +122,7 @@ class AnomalyPoint(AnomalyPointOriginal):
     # severity value rounded to integer
     severity: int
     # percentage change from previous day's point
-    percent_change: Union[int, float, str]
+    percent_change: Union[StrictFloat, StrictInt, str]
     # human readable message describing the percent_change
     change_message: str
 

--- a/chaos_genius/alerts/anomaly_alerts.py
+++ b/chaos_genius/alerts/anomaly_alerts.py
@@ -202,7 +202,7 @@ class AnomalyPointFormatted(AnomalyPoint):
     alert_id: int
     alert_name: str
     alert_channel: str
-    alert_channel_conf: Optional[list]
+    alert_channel_conf: Any
 
     formatted_date: str
     formatted_change_percent: str
@@ -216,7 +216,7 @@ class AnomalyPointFormatted(AnomalyPoint):
         alert_id: int,
         alert_name: str,
         alert_channel: str,
-        alert_channel_conf: Optional[list],
+        alert_channel_conf: Any,
     ) -> "AnomalyPointFormatted":
         """Constructs a formatted point from an AnomalyPoint."""
         dt_format = ALERT_READABLE_DATETIME_FORMAT

--- a/chaos_genius/alerts/anomaly_alerts.py
+++ b/chaos_genius/alerts/anomaly_alerts.py
@@ -202,6 +202,11 @@ class AnomalyPointFormatted(AnomalyPoint):
     alert_id: int
     alert_name: str
     alert_channel: str
+    # stores alert channel configuration
+    # in individual alerts, this will be the entire dict (`Dict`)
+    # in digests, this will be just the list of emails or None (`Optional[List[str]]`)
+    # TODO: make a different type for digest data or use a consistent type across both
+    #  ref: https://github.com/chaos-genius/chaos_genius/pull/862#discussion_r839400411
     alert_channel_conf: Any
 
     formatted_date: str

--- a/chaos_genius/alerts/anomaly_alerts.py
+++ b/chaos_genius/alerts/anomaly_alerts.py
@@ -345,7 +345,7 @@ class AnomalyAlertController:
         logger.info(
             f"Checking for anomalies for (KPI: {self.kpi_id}, Alert: "
             f"{self.alert_id}) in the range - start: {start_timestamp} (included: "
-            f"{include_start_timestamp}) and end: {self.latest_anomaly_timestamp} "
+            f"{include_start_timestamp}) and end: {end_timestamp} "
             "(included: True)"
         )
 
@@ -426,8 +426,6 @@ class AnomalyAlertController:
         prev_day_data = self._get_anomalies(
             time_diff=time_diff, anomalies_only=False, include_severity_cutoff=False
         )
-        for anomaly_point in prev_day_data:
-            anomaly_point.format_series_type()
 
         # store a mapping of hour => list of anomaly points for that hour
         hourly_data: Dict[int, List[AnomalyPointOriginal]] = dict()

--- a/chaos_genius/alerts/email_templates/digest_template.html
+++ b/chaos_genius/alerts/email_templates/digest_template.html
@@ -53,14 +53,16 @@
         <span style="color: lightgrey;">
             changed to <strong>{{point.y}}</strong>
         {% if point.percent_change is string and "inf" not in point.percent_change %}
-        (<span>{{ point.formatted_change_percent }}</span>)
+            (<span>
         {% elif "+inf" in str(point.percent_change) or point.percent_change > 0 %}
-        (<span style="color: lightgreen;">{{ point.formatted_change_percent }}</span>)
+            (<span style="color: lightgreen;">
         {% elif "-inf" in str(point.percent_change) or point.percent_change < 0 %}
-        (<span style="color: red;">{{ point.formatted_change_percent }}</span>)
+            (<span style="color: red;">
         {% else %}
-        (<span>{{ point.formatted_change_percent }}</span>)
+            (<span>
         {% endif %}
+            {{ point.formatted_change_percent }}
+            </span>)
         on {{ point.formatted_date }}
         (expected: <strong>{{point.yhat_lower}}</strong> to <strong>{{point.yhat_upper}}</strong>,
         severity:

--- a/chaos_genius/alerts/email_templates/digest_template.html
+++ b/chaos_genius/alerts/email_templates/digest_template.html
@@ -52,21 +52,21 @@
         <strong><a class="kpi-link" href="{{ kpi_link_prefix }}/{{ point.kpi_id }}">{{point.kpi_name}} ({{point.series_type}})</strong></a>
         <span style="color: lightgrey;">
             changed to <strong>{{point.y}}</strong>
-        {% if point.percent_change is string and "inf" not in point.percent_change %}
-            <span>
-        {% elif "+inf" in str(point.percent_change) or point.percent_change > 0 %}
-            <span style="color: lightgreen;">
-        {% elif "-inf" in str(point.percent_change) or point.percent_change < 0 %}
-            <span style="color: red;">
-        {% else %}
-            <span>
-        {% endif %}
-            ({{ point.formatted_change_percent }})
-            </span>
-        on {{ point.formatted_date }}
-        (expected: <strong>{{point.yhat_lower}}</strong> to <strong>{{point.yhat_upper}}</strong>,
-        severity:
-        <strong>{{point.severity}}</strong>)
+            {% if point.percent_change is string and "inf" not in point.percent_change %}
+                <span>
+            {% elif "+inf" in str(point.percent_change) or point.percent_change > 0 %}
+                <span style="color: lightgreen;">
+            {% elif "-inf" in str(point.percent_change) or point.percent_change < 0 %}
+                <span style="color: red;">
+            {% else %}
+                <span>
+            {% endif %}
+                ({{ point.formatted_change_percent }})
+                </span>
+            on {{ point.formatted_date }}
+            (expected: <strong>{{point.yhat_lower}}</strong> to <strong>{{point.yhat_upper}}</strong>,
+            severity:
+            <strong>{{point.severity}}</strong>)
         </span>
     </li>
     {% endfor %}

--- a/chaos_genius/alerts/email_templates/digest_template.html
+++ b/chaos_genius/alerts/email_templates/digest_template.html
@@ -53,16 +53,16 @@
         <span style="color: lightgrey;">
             changed to <strong>{{point.y}}</strong>
         {% if point.percent_change is string and "inf" not in point.percent_change %}
-            (<span>
+            <span>
         {% elif "+inf" in str(point.percent_change) or point.percent_change > 0 %}
-            (<span style="color: lightgreen;">
+            <span style="color: lightgreen;">
         {% elif "-inf" in str(point.percent_change) or point.percent_change < 0 %}
-            (<span style="color: red;">
+            <span style="color: red;">
         {% else %}
-            (<span>
+            <span>
         {% endif %}
-            {{ point.formatted_change_percent }}
-            </span>)
+            ({{ point.formatted_change_percent }})
+            </span>
         on {{ point.formatted_date }}
         (expected: <strong>{{point.yhat_lower}}</strong> to <strong>{{point.yhat_upper}}</strong>,
         severity:

--- a/chaos_genius/alerts/email_templates/digest_template.html
+++ b/chaos_genius/alerts/email_templates/digest_template.html
@@ -53,13 +53,13 @@
         <span style="color: lightgrey;">
             changed to <strong>{{point.y}}</strong>
         {% if point.percent_change is string and "inf" not in point.percent_change %}
-        (<span>{{ point["change_message"] }}</span>)
+        (<span>{{ point.formatted_change_percent }}</span>)
         {% elif "+inf" in str(point.percent_change) or point.percent_change > 0 %}
-        (<span style="color: lightgreen;">{{ point.change_message }}</span>)
+        (<span style="color: lightgreen;">{{ point.formatted_change_percent }}</span>)
         {% elif "-inf" in str(point.percent_change) or point.percent_change < 0 %}
-        (<span style="color: red;">{{ point.change_message }}</span>)
+        (<span style="color: red;">{{ point.formatted_change_percent }}</span>)
         {% else %}
-        (<span>{{ point.change_message }}</span>)
+        (<span>{{ point.formatted_change_percent }}</span>)
         {% endif %}
         on {{ point.formatted_date }}
         (expected: <strong>{{point.yhat_lower}}</strong> to <strong>{{point.yhat_upper}}</strong>,

--- a/chaos_genius/alerts/email_templates/email_alert.html
+++ b/chaos_genius/alerts/email_templates/email_alert.html
@@ -60,21 +60,23 @@
     {% for point in top_anomalies %}
     <li>
         <strong>{{kpi_name}} ({{point.series_type}})</strong>
-        <span style="color: lightgrey;">changed to
-        <strong>{{point.y}}</strong>
-        {% if point.percent_change is string and "inf" not in point.percent_change %}
-        (<span><strong>{{ point.formatted_change_percent }}</strong></span>)
-        {% elif "+inf" in str(point.percent_change) or point.percent_change > 0 %}
-        <span style="color: lightgreen;">({{ point.formatted_change_percent }})</span>
-        {% elif "-inf" in str(point.percent_change) or point.percent_change < 0 %}
-        <span style="color: red;">({{ point.formatted_change_percent }})</span>
-        {% else %}
-        (<span><strong>{{ point.formatted_change_percent }}</strong></span>)
-        {% endif %}
-        on {{ point.formatted_date }}
-        (expected: <strong>{{point.yhat_lower}}</strong> to <strong>{{point.yhat_upper}}</strong>,
-        severity:
-        <strong>{{point.severity}}</strong>)
+        <span style="color: lightgrey;">
+            changed to <strong>{{point.y}}</strong>
+            {% if point.percent_change is string and "inf" not in point.percent_change %}
+                <span>
+            {% elif "+inf" in str(point.percent_change) or point.percent_change > 0 %}
+                <span style="color: lightgreen;">
+            {% elif "-inf" in str(point.percent_change) or point.percent_change < 0 %}
+                <span style="color: red;">
+            {% else %}
+                <span>
+            {% endif %}
+                ({{ point.formatted_change_percent }})
+                </span>
+            on {{ point.formatted_date }}
+            (expected: <strong>{{point.yhat_lower}}</strong> to <strong>{{point.yhat_upper}}</strong>,
+            severity:
+            <strong>{{point.severity}}</strong>)
         </span>
     </li>
     {% endfor %}

--- a/chaos_genius/alerts/slack.py
+++ b/chaos_genius/alerts/slack.py
@@ -61,8 +61,8 @@ def anomaly_alert_slack(
                 "text": {
                     "type": "mrkdwn",
                     "text": (
-                        f"- Total alerts generated (Overall KPI): *{overall_count}*\n"
-                        "- Total alerts generated (including subdimenions): "
+                        f"- Total alerts generated (Overall KPI): *{overall_count}*\n" +
+                        "- Total alerts generated (including subdimenions): " +
                         f"*{subdim_count + overall_count}*\n"
                     ),
                 },
@@ -180,7 +180,7 @@ def _format_slack_anomalies(
 
         if include_kpi_link:
             kpi_name_link = (
-                f"<{webapp_url_prefix()}#/dashboard/0/anomaly/{point.kpi_id}"
+                f"<{webapp_url_prefix()}#/dashboard/0/anomaly/{point.kpi_id}" +
                 f"|{point.kpi_name} (*{point.series_type}*)>"
             )
         else:
@@ -191,8 +191,8 @@ def _format_slack_anomalies(
         threshold_message = f"expected: *{point.yhat_lower} to {point.yhat_upper}*"
 
         out += (
-            f"- *{kpi_name_link}* changed to "
-            f"*{point.y}* (*{point.formatted_change_percent}*) "
+            f"- *{kpi_name_link}* changed to " +
+            f"*{point.y}* (*{point.formatted_change_percent}*) " +
             f"on {date} ({threshold_message}, severity: *{point.severity}*)\n"
         )
 
@@ -239,8 +239,8 @@ def alert_digest_slack_formatted(
                 "text": {
                     "type": "mrkdwn",
                     "text": (
-                        f"- Total alerts generated (Overall KPI): *{overall_count}*\n"
-                        "- Total alerts generated (including subdimenions): "
+                        f"- Total alerts generated (Overall KPI): *{overall_count}*\n" +
+                        "- Total alerts generated (including subdimenions): " +
                         f"*{subdim_count + overall_count}*\n"
                     ),
                 },

--- a/chaos_genius/alerts/slack.py
+++ b/chaos_genius/alerts/slack.py
@@ -192,7 +192,7 @@ def _format_slack_anomalies(
 
         out += (
             f"- *{kpi_name_link}* changed to "
-            f"*{point.y}* (*{point.change_message}*) "
+            f"*{point.y}* (*{point.formatted_change_percent}*) "
             f"on {date} ({threshold_message}, severity: *{point.severity}*)\n"
         )
 

--- a/chaos_genius/controllers/digest_controller.py
+++ b/chaos_genius/controllers/digest_controller.py
@@ -59,6 +59,8 @@ def preprocess_triggered_alert(
     if not isinstance(alert_conf.alert_channel_conf, dict):
         triggered_alert.alert_channel_conf = None
     else:
+        # in case of email, this makes triggered_alert.alert_channel_conf the list of
+        #  emails
         triggered_alert.alert_channel_conf = getattr(
             alert_conf, "alert_channel_conf", {}
         ).get(triggered_alert.alert_channel, None)

--- a/chaos_genius/controllers/digest_controller.py
+++ b/chaos_genius/controllers/digest_controller.py
@@ -63,7 +63,7 @@ def preprocess_triggered_alert(
         #  emails
         triggered_alert.alert_channel_conf = getattr(
             alert_conf, "alert_channel_conf", {}
-        ).get(triggered_alert.alert_channel, None)
+        ).get(triggered_alert.alert_channel)
 
     return triggered_alert
 


### PR DESCRIPTION
## Changes

Some fixes made after testing alerts post #836.

1. type issue in `alert_channel_conf` field of `AnomalyPointFormatted` dataclass
1. Removed series_type formatting for previous day data
1. Use strict type versions of int and float to prevent type conversion from str to int/float
1. Make Slack individual alert and email digest formats consistent