### PR TITLE
table-list/table-info handlings incase of 3rd party datasource

### DIFF
--- a/chaos_genius/views/data_source_view.py
+++ b/chaos_genius/views/data_source_view.py
@@ -624,10 +624,11 @@ def get_schema_tables():
                 )
 
             ds_name = getattr(ds_data, "connection_type")
-            schema = None if SCHEMAS_AVAILABLE[ds_name] == False else schema
-
+            schema = (
+                None if (ds_data.is_third_party or SCHEMAS_AVAILABLE[ds_name] == False) else schema
+            )
             if ds_data.is_third_party:
-                table_names = get_table_list(ds_data.as_dict, schema)
+                table_names = ds_data.as_dict["dbConfig"]["tables"]
             else:
                 table_names = fetch_table_list(ds_data.id, schema)
             if table_names is None:
@@ -718,7 +719,9 @@ def get_table_info():
 
         ds_name = getattr(ds_data, "connection_type")
 
-        schema = None if SCHEMAS_AVAILABLE[ds_name] == False else schema
+        schema = (
+            None if ds_data.is_third_party or SCHEMAS_AVAILABLE[ds_name] == False else schema
+        )
 
         if ds_data.is_third_party:
             table_info = get_table_metadata(ds_data.as_dict, schema, table_name)

--- a/chaos_genius/views/data_source_view.py
+++ b/chaos_genius/views/data_source_view.py
@@ -725,7 +725,7 @@ def get_table_info():
         ds_name = getattr(ds_data, "connection_type")
 
         schema = (
-            None if ds_data.is_third_party or SCHEMAS_AVAILABLE[ds_name] == False else schema
+            None if (ds_data.is_third_party or not SCHEMAS_AVAILABLE[ds_name]) else schema
         )
 
         if ds_data.is_third_party:

--- a/chaos_genius/views/data_source_view.py
+++ b/chaos_genius/views/data_source_view.py
@@ -630,7 +630,7 @@ def get_schema_tables():
 
             ds_name = getattr(ds_data, "connection_type")
             schema = (
-                None if (ds_data.is_third_party or SCHEMAS_AVAILABLE[ds_name] == False) else schema
+                None if (ds_data.is_third_party or not SCHEMAS_AVAILABLE[ds_name]) else schema
             )
             if ds_data.is_third_party:
                 table_names = ds_data.as_dict["dbConfig"]["tables"]


### PR DESCRIPTION
- as part of Prefetch metadata changes, we started using same apis (`list-schema`, `table-list`, `table-info`) for all 3rd-party or other datasources as opposed to previous branching logic on frontend to call diff apis 
- `table-list` api and `table-info` were not working for 3rd party, the updates here fixes it