### PR TITLE
chore(ci): add step to check if migrations have diverged

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -34,8 +34,11 @@ jobs:
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 chaos_genius --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 chaos_genius --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # exit-zero treats all errors as warnings.
+        flake8 chaos_genius --count --exit-zero --statistics
     - name: Test with pytest
       run: |
         pytest
+    - name: Check diverged migrations
+      run: |
+        ./scripts/check_diverged_migrations.sh

--- a/scripts/check_diverged_migrations.sh
+++ b/scripts/check_diverged_migrations.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HEADS=`flask db heads`
+
+if [ `echo "$HEADS" | wc -l` -gt 1 ]
+then
+    echo "Migrations have diverged - there are more than one heads!"
+    echo "$HEADS"
+    exit 1
+else
+    echo "Migrations have not diverged"
+    exit 0
+fi


### PR DESCRIPTION
## Changes

The script prints a message with the IDs of the two heads if migrations have diverged. Also returns an appropriate error code for CI.

Added this as the last step in CI to check on every PR.

Also removed overridden flake8 arguments in the linting step. We have a `.flake8` config in the project root for these args.