### PR TITLE
fix(alerts): use inline styles in email templates

### DIFF
--- a/chaos_genius/alerts/email_templates/README.md
+++ b/chaos_genius/alerts/email_templates/README.md
@@ -1,0 +1,10 @@
+# HTML templates for Email alerts
+
+These are the Jinja templates used for sending email alerts.
+
+## Notes for contributing/making changes to these files
+
+- All CSS styles must be inlined to each HTML element. Style tags are not supported well and the formatting may break when an email is forwarded or is inside a thread.
+- Use [this tool](https://templates.mailchimp.com/resources/inline-css/) to automatically convert style tags to inline CSS.
+    - NOTE: recheck the HTML generated from this - especially the tags that included Jinja template variables. The tool does not understand Jinja template blocks such as if, while, etc. which could lead to multiple extra closing or opening blocks being added. Also check for attributes which are assigned to a template variable.
+    - TODO: find a better tool that can work with Jinja templates.

--- a/chaos_genius/alerts/email_templates/digest_template.html
+++ b/chaos_genius/alerts/email_templates/digest_template.html
@@ -1,39 +1,12 @@
 {% extends "layout.html" %}
 
-{% block head %}
-<style>
-.digest-container {
-    color: #F6F5F5 !important;
-}
-
-.btn {
-    appearance: button;
-    cursor: pointer;
-    border-radius: 10px;
-    border-width: 0;
-    background-color: #60CA9A;
-    color: black !important;
-    height: 2rem;
-    line-height: 2rem;
-    padding: 0 1rem;
-    margin-bottom: 1rem;
-    text-decoration: none;
-    display: inline-block;
-}
-
-.kpi-link {
-    color: white !important;
-}
-</style>
-{% endblock %}
-
 {% block content %}
 
 <h2 style="margin-bottom: 15px; color: #F6F5F5">Daily Alert Digest</h2>
 
-<hr />
+<hr>
 
-<div class="digest-container">
+<div class="digest-container" style="color: #F6F5F5 !important;">
 
 <h3>Summary</h3>
 <ul>
@@ -41,15 +14,15 @@
     <li>Total alerts generated (including subdimensions): {{ overall_count + subdim_count }}</li>
 </ul>
 
-<a class="btn" href={{ alert_dashboard_link }}>Alerts Dashboard</a>
+<a class="btn" href="{{ alert_dashboard_link }}" style="appearance: button;cursor: pointer;border-radius: 10px;border-width: 0;background-color: #60CA9A;height: 2rem;line-height: 2rem;padding: 0 1rem;margin-bottom: 1rem;text-decoration: none;display: inline-block;color: black !important;">Alerts Dashboard</a>
 
-<hr />
+<hr>
 
 <h3>Top 10 Anomalies</h3>
 <ul>
     {% for point in top_anomalies %}
     <li>
-        <strong><a class="kpi-link" href="{{ kpi_link_prefix }}/{{ point.kpi_id }}">{{point.kpi_name}} ({{point.series_type}})</strong></a>
+        <strong><a class="kpi-link" href="{{ kpi_link_prefix }}/{{ point.kpi_id }}" style="color: white !important;">{{point.kpi_name}} ({{point.series_type}})</a></strong>
         <span style="color: lightgrey;">
             changed to <strong>{{point.y}}</strong>
             {% if point.percent_change is string and "inf" not in point.percent_change %}

--- a/chaos_genius/alerts/email_templates/email_alert.html
+++ b/chaos_genius/alerts/email_templates/email_alert.html
@@ -1,37 +1,10 @@
 {% extends "layout.html" %}
 
-{% block head %}
-<style>
-.alert-container {
-    color: #F6F5F5 !important;
-}
-
-.btn {
-    appearance: button;
-    cursor: pointer;
-    border-radius: 5px;
-    border-width: 0;
-    background-color: #60CA9A;
-    color: black !important;
-    height: 2rem;
-    line-height: 2rem;
-    padding: 0 1rem;
-    margin-bottom: 1rem;
-    text-decoration: none;
-    display: inline-block;
-}
-
-.kpi-link {
-    color: #60CA9A !important;
-}
-</style>
-{% endblock %}
-
 {% block content %}
 
 <h2 style="margin-bottom: 15px; color: #F6F5F5">{{ alert_name }}</h2>
 
-<hr />
+<hr>
 
 <div class="alert-container" style="color: #F6F5F5 !important;">
 
@@ -50,10 +23,10 @@
 {{ alert_message }}
 </div>
 
-<a class="btn" href={{ kpi_link }}>View KPI</a>
-<a class="btn" href={{ alert_dashboard_link }}>Alerts Dashboard</a>
+<a class="btn" href="{{ kpi_link }}" style="appearance: button;cursor: pointer;border-radius: 5px;border-width: 0;background-color: #60CA9A;height: 2rem;line-height: 2rem;padding: 0 1rem;margin-bottom: 1rem;text-decoration: none;display: inline-block;color: black !important;">View KPI</a>
+<a class="btn" href="{{ alert_dashboard_link }}" style="appearance: button;cursor: pointer;border-radius: 5px;border-width: 0;background-color: #60CA9A;height: 2rem;line-height: 2rem;padding: 0 1rem;margin-bottom: 1rem;text-decoration: none;display: inline-block;color: black !important;">Alerts Dashboard</a>
 
-<hr />
+<hr>
 
 <h3>Top Anomalies</h3>
 <ul>


### PR DESCRIPTION
Fixes #724

## Changes

- Changed email template of individual and digest email alerts to make the styles inlined into each HTML element. This prevents broken formatting when the email exists in a thread or when it is forwarded.
- Tested locally.
- Also added a README documenting this process.