### PR TITLE
0.6.0 version upgrade and avoid misleading timezone deprecation warning

### DIFF
--- a/chaos_genius/core/utils/constants.py
+++ b/chaos_genius/core/utils/constants.py
@@ -1,8 +1,6 @@
 """Provides constants for Chaos Genius."""
 
 SUPPORTED_TIMEZONES = {
-    "GMT": "GMT+00:00",
-    "UTC": "GMT+00:00",
     "ECT": "GMT+01:00",
     "EET": "GMT+02:00",
     "ART": "GMT+02:00",

--- a/chaos_genius/settings.py
+++ b/chaos_genius/settings.py
@@ -102,7 +102,7 @@ IN_DOCKER = _make_bool(os.getenv('IN_DOCKER', default=False))
 TASK_CHECKPOINT_LIMIT: int = int(os.getenv("TASK_CHECKPOINT_LIMIT", 1000))
 """Number of last checkpoints to retrieve in Task Monitor"""
 
-CHAOSGENIUS_VERSION_MAIN = os.getenv("CHAOSGENIUS_VERSION_MAIN", "0.5.2")
+CHAOSGENIUS_VERSION_MAIN = os.getenv("CHAOSGENIUS_VERSION_MAIN", "0.6.0")
 """ChaosGenius version - semver part only"""
 CHAOSGENIUS_VERSION_POSTFIX = os.getenv("CHAOSGENIUS_VERSION_POSTFIX", "git")
 """ChaosGenius version - postfix to identify deployment"""

--- a/docker-compose.thirdparty.yml
+++ b/docker-compose.thirdparty.yml
@@ -38,7 +38,7 @@ services:
 
   chaosgenius-server:
     container_name: chaosgenius-server
-    image: chaosgenius/chaosgenius-server:0.5.2
+    image: chaosgenius/chaosgenius-server:0.6.0
     command: sh setup/run-backend-docker.sh
     restart: unless-stopped
     volumes:
@@ -95,7 +95,7 @@ services:
 
   chaosgenius-webapp:
     container_name: chaosgenius-webapp
-    image: chaosgenius/chaosgenius-webapp:0.5.2
+    image: chaosgenius/chaosgenius-webapp:0.6.0
     command: >
       sh -c "npx react-inject-env set -d ./ &&
              nginx -g 'daemon off;'"
@@ -136,7 +136,7 @@ services:
     
   chaosgenius-scheduler:
     container_name: chaosgenius-scheduler
-    image: chaosgenius/chaosgenius-server:0.5.2
+    image: chaosgenius/chaosgenius-server:0.6.0
     command: celery -A run.celery beat --loglevel=DEBUG
     restart: unless-stopped
     environment:
@@ -173,7 +173,7 @@ services:
   
   chaosgenius-worker-analytics:
     container_name: chaosgenius-worker-analytics
-    image: chaosgenius/chaosgenius-server:0.5.2
+    image: chaosgenius/chaosgenius-server:0.6.0
     command: celery -A run.celery worker --loglevel=INFO --concurrency=2 -P processes -Q anomaly-rca
     restart: unless-stopped
     environment:
@@ -226,7 +226,7 @@ services:
 
   chaosgenius-worker-alerts:
     container_name: chaosgenius-worker-alerts
-    image: chaosgenius/chaosgenius-server:0.5.2
+    image: chaosgenius/chaosgenius-server:0.6.0
     command: celery -A run.celery worker --loglevel=INFO --concurrency=2 -P processes -Q alerts
     restart: unless-stopped
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ x-version:
 services:
   chaosgenius-server:
     container_name: chaosgenius-server
-    image: chaosgenius/chaosgenius-server:0.5.2
+    image: chaosgenius/chaosgenius-server:0.6.0
     command: sh setup/run-backend-docker.sh
     restart: unless-stopped
     volumes:
@@ -68,7 +68,7 @@ services:
 
   chaosgenius-webapp:
     container_name: chaosgenius-webapp
-    image: chaosgenius/chaosgenius-webapp:0.5.2
+    image: chaosgenius/chaosgenius-webapp:0.6.0
     command: >
       sh -c "npx react-inject-env set -d ./ &&
              nginx -g 'daemon off;'"
@@ -107,7 +107,7 @@ services:
     
   chaosgenius-scheduler:
     container_name: chaosgenius-scheduler
-    image: chaosgenius/chaosgenius-server:0.5.2
+    image: chaosgenius/chaosgenius-server:0.6.0
     command: celery -A run.celery beat --loglevel=DEBUG
     restart: unless-stopped
     environment:
@@ -144,7 +144,7 @@ services:
   
   chaosgenius-worker-analytics:
     container_name: chaosgenius-worker-analytics
-    image: chaosgenius/chaosgenius-server:0.5.2
+    image: chaosgenius/chaosgenius-server:0.6.0
     command: celery -A run.celery worker --loglevel=INFO --concurrency=2 -P processes -Q anomaly-rca
     restart: unless-stopped
     environment:
@@ -197,7 +197,7 @@ services:
 
   chaosgenius-worker-alerts:
     container_name: chaosgenius-worker-alerts
-    image: chaosgenius/chaosgenius-server:0.5.2
+    image: chaosgenius/chaosgenius-server:0.6.0
     command: celery -A run.celery worker --loglevel=INFO --concurrency=2 -P processes -Q alerts
     restart: unless-stopped
     environment:


### PR DESCRIPTION
- Updated backend and frontend docker images tags from 0.5.2 to 0.6.0 in `docker-compose.yml` and `docker-compose.thirdparty.yml`

- Changed Version from 0.5.2 to 0.6.0 in `settings.py`