### PR TITLE
fix(alerts): wrong formats when subdims were not present

### DIFF
--- a/chaos_genius/alerts/email_templates/common.html
+++ b/chaos_genius/alerts/email_templates/common.html
@@ -216,7 +216,7 @@
         {%- endif %}
     {%- endif %}<!--
 
- -->{% if point.relevant_subdims is not none -%}
+ -->{% if point.relevant_subdims -%}
         <ul>
             <li>
                 <span style="{{ non_important_text }}">Reasons for change:</span>

--- a/chaos_genius/alerts/email_templates/email_alert.html
+++ b/chaos_genius/alerts/email_templates/email_alert.html
@@ -40,7 +40,7 @@
 </ul>
 {% endif %}
 
-{% if data.include_subdims %}
+{% if data.include_subdims and data.top_subdim_points %}
 <h3 style="{{ common.main_text }}">Sub-dimensional anomalies</h3>
 <ul>
     {% for point in data.top_subdim_points %}

--- a/chaos_genius/alerts/slack.py
+++ b/chaos_genius/alerts/slack.py
@@ -109,40 +109,40 @@ def alert_digest_slack_formatted(data: "AlertsReportData") -> str:
         raise Exception("Slack not configured properly.")
 
     blocks = [
-            {
-                "type": "header",
-                "text": {
-                    "type": "plain_text",
-                    "text": f"Daily Alerts Report ({data.report_date_formatted()})",
-                    "emoji": True,
-                },
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": f"Daily Alerts Report ({data.report_date_formatted()})",
+                "emoji": True,
             },
-            {
-                "type": "divider",
+        },
+        {
+            "type": "divider",
+        },
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": "Top Anomalies",
+                "emoji": True,
             },
-            {
-                "type": "header",
-                "text": {
-                    "type": "plain_text",
-                    "text": "Top Anomalies",
-                    "emoji": True,
-                },
-            },
-            *_display_anomalies_digest(data),
-            *_display_anomalies_digest(data, subdim=True),
-            {
-                "type": "actions",
-                "elements": [
-                    {
-                        "type": "button",
-                        "text": {"type": "plain_text", "text": "Alerts Dashboard"},
-                        "url": data.alert_dashboard_link(),
-                        "action_id": "alert_dashboard",
-                        "style": "primary",
-                    }
-                ],
-            },
-        ]
+        },
+        *_display_anomalies_digest(data),
+        *_display_anomalies_digest(data, subdim=True),
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Alerts Dashboard"},
+                    "url": data.alert_dashboard_link(),
+                    "action_id": "alert_dashboard",
+                    "style": "primary",
+                }
+            ],
+        },
+    ]
 
     response = client.send(blocks=blocks)
 
@@ -157,10 +157,7 @@ def _display_anomalies_individual(anomaly_data, subdim: bool = False):
     sections: List[Dict[str, Any]] = []
     section = {
         "type": "section",
-        "text": {
-            "type": "mrkdwn",
-            "text": ""
-        },
+        "text": {"type": "mrkdwn", "text": ""},
     }
 
     if not subdim:
@@ -199,10 +196,7 @@ def _display_anomalies_digest(anomaly_data, subdim: bool = False):
     def _new_text_section() -> Dict[str, Any]:
         section = {
             "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": ""
-            },
+            "text": {"type": "mrkdwn", "text": ""},
         }
         sections.append(section)
         return section
@@ -259,14 +253,10 @@ def subdim_name_link(point, value_only: bool = False):
     """Creates subdim name with link to respective subdim anomaly page."""
     if value_only:
         subdim_link = (
-            f"<{point.subdim_link()}"
-            + f"|{point.subdim_formatted_value_only()}>"
+            f"<{point.subdim_link()}" + f"|{point.subdim_formatted_value_only()}>"
         )
     else:
-        subdim_link = (
-            f"<{point.subdim_link()}"
-            + f"|{point.subdim_formatted()}>"
-        )
+        subdim_link = f"<{point.subdim_link()}" + f"|{point.subdim_formatted()}>"
     return subdim_link
 
 

--- a/chaos_genius/alerts/slack.py
+++ b/chaos_genius/alerts/slack.py
@@ -28,7 +28,6 @@ def anomaly_alert_slack(
 
     Returns an empty string if successful or the error as a string if not.
     """
-    # TODO: Fix this implementation to use AlertsIndividualData
     client = get_webhook_client()
     response = client.send(
         blocks=[
@@ -169,7 +168,7 @@ def _display_anomalies_individual(anomaly_data, subdim: bool = False):
                 section["text"]["text"] += point_formatted
         sections.append(section)
     else:
-        if anomaly_data.include_subdims:
+        if anomaly_data.include_subdims and anomaly_data.top_subdim_points:
             header_section = {
                 "type": "header",
                 "text": {
@@ -321,7 +320,7 @@ def anomaly_point_formatting(
                 + f" to {point.anomaly_time_only}"
             )
 
-    if point.relevant_subdims is not None:
+    if point.relevant_subdims:
         out += "\n      - Reasons for change: "
         for point in point.top_relevant_subdims() or []:
             out += f"{subdim_name_link(point, value_only=True)}, "


### PR DESCRIPTION
## Changes

- "Sub-dimensional anomalies" heading was present even when there weren't any subdim anomalies in individual alerts.
- "Reasons for change" text was present even when there weren't any relevant subdims.

## Notes for reviewers

See diff without code formatting changes: https://github.com/chaos-genius/chaos_genius/compare/06da2ff8345ce0bc7d67c4387aeae1cdeb2c3ceb...fix/alerts-relevant-subdims-empty