### PR TITLE
feat(alerts): add CSV to email alert report, better CSV names

### DIFF
--- a/chaos_genius/alerts/anomaly_alerts.py
+++ b/chaos_genius/alerts/anomaly_alerts.py
@@ -58,7 +58,7 @@ from chaos_genius.databases.models.alert_model import Alert
 from chaos_genius.databases.models.kpi_model import Kpi
 from chaos_genius.databases.models.triggered_alerts_model import TriggeredAlerts
 from chaos_genius.settings import DAYS_OFFSET_FOR_ANALTYICS
-from chaos_genius.utils.utils import jsonable_encoder
+from chaos_genius.utils.utils import jsonable_encoder, make_path_safe
 
 logger = logging.getLogger(__name__)
 
@@ -1034,7 +1034,7 @@ class AnomalyAlertController:
         files = [
             {
                 "fname": (
-                    f"chaosgenius_alert_{individual_data.kpi_name}"
+                    f"chaosgenius_alert_{make_path_safe(individual_data.kpi_name)}"
                     f"_{filename_date}.csv"
                 ),
                 "fdata": make_anomaly_data_csv(

--- a/chaos_genius/alerts/base_alert_digests.py
+++ b/chaos_genius/alerts/base_alert_digests.py
@@ -4,7 +4,11 @@ import logging
 from collections import defaultdict
 from typing import DefaultDict, Dict, List, Set, Tuple
 
-from chaos_genius.alerts.constants import FREQUENCY_DICT
+from chaos_genius.alerts.anomaly_alerts import make_anomaly_data_csv
+from chaos_genius.alerts.constants import (
+    ALERT_DATE_CSV_FILENAME_FORMAT_REPORT,
+    FREQUENCY_DICT,
+)
 from chaos_genius.alerts.slack import alert_digest_slack_formatted
 from chaos_genius.alerts.utils import send_email_using_template
 from chaos_genius.controllers.config_controller import get_config_object
@@ -150,6 +154,20 @@ class AlertDigestController:
             )
             return
 
+        # attach CSV of anomaly data
+        filename_date = data.report_date.strftime(ALERT_DATE_CSV_FILENAME_FORMAT_REPORT)
+        files = [
+            {
+                "fname": f"chaosgenius_alerts_report_{filename_date}.csv",
+                "fdata": make_anomaly_data_csv(
+                    data.all_points(),
+                    for_report=True,
+                ),
+                "mime_maintype": "text",
+                "mime_subtype": "csv",
+            }
+        ]
+
         send_email_using_template(
             "digest_template.html",
             [recipient],
@@ -157,7 +175,7 @@ class AlertDigestController:
                 f"Daily Alerts Report ({data.report_date_formatted()}) - "
                 "Chaos Genius Alert❗"
             ),
-            [],
+            files,
             preview_text="",
             data=data,
         )

--- a/chaos_genius/alerts/constants.py
+++ b/chaos_genius/alerts/constants.py
@@ -15,6 +15,12 @@ ALERT_READABLE_DATA_TIMESTAMP_FORMAT = "%b %d %Y %H:%M:%S"
 ALERT_READABLE_DATA_TIME_ONLY_FORMAT = "%I %p"
 """Format for time (without date) of anomaly."""
 
+ALERT_DATE_CSV_FILENAME_FORMAT_INDIVIDUAL = "%Y-%m-%d"
+"""Date format to be included in the CSV file name for individual alerts."""
+
+ALERT_DATE_CSV_FILENAME_FORMAT_REPORT = "%Y-%m-%d"
+"""Date format to be included in the CSV file name for report alerts."""
+
 ANOMALY_TABLE_COLUMN_NAMES_MAPPER = {
     "series_type": "Dimension",
     "data_datetime": "Time of Occurrence",
@@ -24,6 +30,9 @@ ANOMALY_TABLE_COLUMN_NAMES_MAPPER = {
     "expected_value": "Expected Value",
     "previous_value": "Previous Value",
 }
+ANOMALY_REPORT_COLUMN_NAMES_MAPPER = dict(
+    ANOMALY_TABLE_COLUMN_NAMES_MAPPER, kpi_name="KPI Name"
+)
 ANOMALY_TABLE_COLUMN_NAMES_ORDERED = [
     "series_type",
     "data_datetime",
@@ -33,6 +42,7 @@ ANOMALY_TABLE_COLUMN_NAMES_ORDERED = [
     "severity",
     "expected_value",
 ]
+ANOMALY_REPORT_COLUMN_NAMES_ORDERED = ["kpi_name"] + ANOMALY_TABLE_COLUMN_NAMES_ORDERED
 
 FREQUENCY_DICT = {
     "weekly": datetime.timedelta(days=7, hours=0, minutes=0),

--- a/chaos_genius/alerts/email.py
+++ b/chaos_genius/alerts/email.py
@@ -126,8 +126,16 @@ def send_static_alert_email(
     for file_detail in files:
         fname = file_detail["fname"]
         fdata = file_detail["fdata"]
-        attachment = MIMEApplication(fdata, fname)
+        mime_maintype = file_detail.get("mime_maintype", "application")
+        mime_subtype = file_detail.get("mime_subtype", fname)
+
+        if mime_maintype == "text":
+            attachment = MIMEText(fdata, mime_subtype)
+        else:
+            attachment = MIMEApplication(fdata, mime_subtype)
+
         attachment["Content-Disposition"] = 'attachment; filename="{}"'.format(fname)
+
         message.attach(attachment)
 
     send_email(recipient_emails, message, host, port, user, password, sender)

--- a/chaos_genius/controllers/digest_controller.py
+++ b/chaos_genius/controllers/digest_controller.py
@@ -124,6 +124,17 @@ class AlertsReportData(BaseModel):
             top_subdim_anomalies=top_subdim_anomalies,
         )
 
+    def all_points(self) -> List[AnomalyPointFormatted]:
+        """All anomaly points considered in the report."""
+        points = [
+            point
+            for trig_alert in self.triggered_alerts
+            for point in iterate_over_all_points(trig_alert.points, True)
+            if point.is_subdim
+        ]
+
+        return points
+
     @property
     def has_anomalies(self) -> bool:
         """Whether any anomalies have been observed."""

--- a/chaos_genius/utils/utils.py
+++ b/chaos_genius/utils/utils.py
@@ -2,6 +2,7 @@
 """Helper utilities and decorators."""
 import csv
 import io
+import re
 import subprocess
 from typing import Iterator, List
 import time
@@ -83,3 +84,15 @@ def jsonable_encoder(obj):
             obj_dict = obj_dict["__root__"]
         return jsonable_encoder(obj_dict)
     return pydantic_encoder(obj)
+
+
+_invalid_chars_reg = re.compile(r"[^\w\d \[\]\(\)_\-\%]")
+"""Matches characters that are not allowed in a filename."""
+
+
+def make_path_safe(s: str) -> str:
+    """Make a string safe for use as a filename in a path on Linux, MacOS and Windows.
+
+    Does not replace spaces.
+    """
+    return re.sub(_invalid_chars_reg, "_", s)


### PR DESCRIPTION
## Changes

- [x] Modify `make_anomaly_data_csv` to handle reports too
- [x] Make `make_anomaly_data_csv` a public function, to use it in `base_alerts_digest.py`
- [x] Modify `make_anomaly_data_csv` to take `AnomalyPointFormatted` to make it consistent with reports. Also changed creation of `AlertsIndividualData` to store `AnomalyPointFormatted` instead of `AnomalyPoint`.
- [x] Add better file name to individual alert CSV.
    - [x] Change `send_static_alert_email` to not set the mime subtype same as the file name
    - [x] Change `send_static_alert_email` to optionally take the MIME main and sub type
    - [x] Change individual alert CSV dict to include MIME types and better name with KPI name and date
- [x] Add CSV to alert report, with correct MIME types and a nice name