### PR TITLE
fix(anomaly-params): use .get instead of indexing, check rca_time exists

### DIFF
--- a/chaos_genius/views/anomaly_data_view.py
+++ b/chaos_genius/views/anomaly_data_view.py
@@ -1056,7 +1056,8 @@ def update_anomaly_params(
         # daily to hourly.
         if (
             scheduler_params["scheduler_frequency"] != "D"
-            and scheduler_params.get("rca_time") == scheduler_params["time"]
+            and "rca_time" in scheduler_params
+            and scheduler_params.get("rca_time") == scheduler_params.get("time")
         ):
             scheduler_params.pop("rca_time")
 


### PR DESCRIPTION
When setting up an hourly anomaly for the first time, `scheduler_params["time"]` does not exist and throws an error in this part of the code.