### PR TITLE
fix(drilldowns): reset count col before data loading

### DIFF
--- a/chaos_genius/core/rca/rca_controller.py
+++ b/chaos_genius/core/rca/rca_controller.py
@@ -94,6 +94,8 @@ class RootCauseAnalysisController:
         :return: tuple with baseline data and rca data for
         :rtype: Tuple[pd.DataFrame, pd.DataFrame]
         """
+        self._preaggregated_count_col = self.kpi_info["count_column"]
+
         # TODO: Write data loader which can cache data and pull from cache
         (prev_start_date, prev_end_date), (
             curr_start_date,


### PR DESCRIPTION
Drilldowns failed for other timelines after the first as the count column was overidden.