### PR TITLE
fix(migration): consider case when KPI was manually deleted

### DIFF
--- a/migrations/versions/c76670622e1e_add_impact_score.py
+++ b/migrations/versions/c76670622e1e_add_impact_score.py
@@ -42,9 +42,15 @@ def upgrade():
         anom_period_query_result = conn.execute(
             f"SELECT anomaly_params ->> 'anomaly_period', anomaly_params ->> 'frequency' FROM kpi WHERE id={kpi_id}"
         )
-        row = next(anom_period_query_result)
+        anomaly_setup = True
+        try:
+            row = next(anom_period_query_result)
+            if row[0] is None:
+                anomaly_setup = False
+        except StopIteration:
+            anomaly_setup = False
 
-        if row[0]:
+        if anomaly_setup:
             anom_period = int(row[0])
             frequency = row[1]
 


### PR DESCRIPTION
When the KPI did not exist in the kpi table but had anomaly data in the
anomaly_data_output table, the migration would fail with a StopIteration
error as the query did not return rows. This case is handled and the
impact value is set to 0.