### PR TITLE
fix(alert-report): generate CSV for overall anomalies too

### DIFF
--- a/chaos_genius/controllers/digest_controller.py
+++ b/chaos_genius/controllers/digest_controller.py
@@ -130,7 +130,6 @@ class AlertsReportData(BaseModel):
             point
             for trig_alert in self.triggered_alerts
             for point in iterate_over_all_points(trig_alert.points, True)
-            if point.is_subdim
         ]
 
         return points


### PR DESCRIPTION
An extra condition lead to the CSV having only subdim anomalies. When there were no subdim anomalies, the report would fail.