### PR TITLE
fix: check dashboard/datasource active in filter options

### DIFF
--- a/chaos_genius/controllers/dashboard_controller.py
+++ b/chaos_genius/controllers/dashboard_controller.py
@@ -282,6 +282,7 @@ def all_dashboard_names() -> Dict[int, str]:
     return {
         row[0]: row[1]
         for row in db.session.query(Dashboard.id, Dashboard.name)
+        .filter(Dashboard.active == True)  # noqa: E712
         .order_by(Dashboard.name)
         .all()
     }

--- a/chaos_genius/controllers/data_source_controller.py
+++ b/chaos_genius/controllers/data_source_controller.py
@@ -146,6 +146,7 @@ def used_data_source_types() -> List[str]:
     return [
         row[0]
         for row in db.session.query(DataSource.connection_type)
+        .filter(DataSource.active == True)  # noqa: E712
         .order_by(DataSource.connection_type)
         .distinct()
         .all()


### PR DESCRIPTION
These lists are used to populate the filter options in FE.

Fixes #1066

Same as #1068 but this time to the correct branch