### PR TITLE
fix(anomaly): convert y values to float before saving

### DIFF
--- a/chaos_genius/core/anomaly/controller.py
+++ b/chaos_genius/core/anomaly/controller.py
@@ -257,6 +257,8 @@ class AnomalyDetectionController(object):
 
         anomaly_output["created_at"] = datetime.now()
 
+        anomaly_output["y"] = anomaly_output["y"].astype(float)
+
         anomaly_output.to_sql(
             AnomalyDataOutput.__tablename__,
             db.engine,


### PR DESCRIPTION
When the `y` values are integers, anomaly fails while saving with the error `sqlalchemy.exc.ProgrammingError: (psycopg2.ProgrammingError) can't adapt type 'numpy.int64'`.

This is noticeable either with KPIs that have their metric column as an integer type or with Data Quality count.

The commit fixes this by always casting the `y` values to `float`.