### PR TITLE
fix(anomaly): ensure correct data types

### DIFF
--- a/chaos_genius/core/anomaly/processor.py
+++ b/chaos_genius/core/anomaly/processor.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 from typing import Dict, Tuple, Union
 
+import numpy as np
 import pandas as pd
 
 from chaos_genius.core.anomaly.constants import FREQUENCY_DELTA
@@ -105,16 +106,17 @@ class ProcessAnomalyDetection:
         """
         input_data = self.input_data
 
-        pred_series = pd.DataFrame(
-            columns=[
-                "dt",
-                "y",
-                "yhat_lower",
-                "yhat_upper",
-                "anomaly",
-                "severity",
-                "impact",
-            ]
+        pred_series_schema = {
+            "dt": np.datetime64,
+            "y": float,
+            "yhat_lower": float,
+            "yhat_upper": float,
+            "anomaly": int,
+            "severity": float,
+            "impact": float,
+        }
+        pred_series = pd.DataFrame(columns=pred_series_schema.keys()).astype(
+            pred_series_schema
         )
 
         input_last_date = input_data["dt"].iloc[-1]
@@ -169,9 +171,7 @@ class ProcessAnomalyDetection:
                     )
                     prediction["y"] = df["y"].to_list()
 
-                    prediction = pd.DataFrame(prediction.iloc[-1].copy()).T.reset_index(
-                        drop=True
-                    )
+                    prediction = prediction.iloc[[-1]]
 
                     pred_series = pred_series.append(
                         self._calculate_metrics(


### PR DESCRIPTION
## Summary

The empty prediction dataframe is now given the correct types immediately after creation. This ensures that any data appended to the dataframe will have the correct type. Note: if the columns or the dataframe itself is overwritten, this will not hold and the types may change.

Also uses a simpler method to get the last row of the prediction dataframe which prevents loss of types. The earlier version would erase all the metadata and make the dtypes `object`.

These 2 changes ensure that the `y` column is always a `float` and the dataframe correctly identifies it as such. Note: the columns can still be overriden by some other code and this cannot be ensured without writing tests.

## TODO

- [x] Test public KPIs - initial run
- [x] Test public KPIs - subsequent run
- [x] Test KPI with integer metric column - initial run
- [x] Test KPI with integer metric column - subsequent run
- [x] Compare outputs of previous code and new code for each case