### PR TITLE
fix(anomaly): convert slack into hourly value for hourly KPIs

### DIFF
--- a/chaos_genius/core/anomaly/controller.py
+++ b/chaos_genius/core/anomaly/controller.py
@@ -76,7 +76,11 @@ class AnomalyDetectionController(object):
             self.debug = True
         if self.debug == "False":
             self.debug = False
-        self.slack = MAX_ANOMALY_SLACK_DAYS
+        self.slack = (
+            MAX_ANOMALY_SLACK_DAYS * 24
+            if self.kpi_info["anomaly_params"]["frequency"] == "H"
+            else MAX_ANOMALY_SLACK_DAYS
+        )
 
         if self.kpi_info["anomaly_params"]["frequency"] == "H":
             period = int(self.kpi_info["anomaly_params"]["anomaly_period"]) * 24


### PR DESCRIPTION
Tested on:

- [x] Daily KPI
- [x] Hourly KPI with no missing data
- [x] Hourly KPI with missing data