### PR TITLE
chore: increase dependabot pip PR limit to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
       - "pip dependencies"
     reviewers:
       - "varunp2k"
-#     open-pull-requests-limit: 10
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
Some version upgrades are deferred, which blocks other version upgrades unnecessarily.