### PR TITLE
Upgrade analytics libraries

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -4,7 +4,7 @@ requests==2.25.1
 # pinned transitive dependencies
 pyparsing==3.0.9
 python-dateutil==2.8.2
-pytz==2022.1
+pytz==2022.2.1
 PyJWT==2.4.0
 PyYAML==6.0
 pyOpenSSL==21.0.0
@@ -65,11 +65,10 @@ tabulate==0.8.9
 matplotlib==3.4.2
 numpy==1.22.2
 numpyencoder==0.3.0
-pandas==1.3.5
-pystan==2.19.1.1
+pandas==1.4.4
 altair==4.1.0
-statsmodels==0.12.2
-prophet==1.0.1
+statsmodels==0.13.2
+prophet==1.1
 # neuralprophet==0.2.7
 # greykite==0.2.0
 


### PR DESCRIPTION
bump python libraries:

- pytz from `2022.1` to `2022.2.1`
- pandas from `1.3.5` to `1.4.4`
- statsmodels from `0.12.2` to `0.13.2`
- prophet from `1.0.1` to `1.1`
- remove pystan

Testing:

- [x] Anomaly Detection for Daily KPI - EWMA, Prophet, ETS
- [x] Anomaly Detection for Hourly KPI - EWMA, Prophet, ETS
- [x] Tz-aware Anomaly Detection for Hourly KPI w/ Prophet
- [x] RCA for Daily and Hourly KPI