### PR TITLE
fix(datasource): use case-insensitive check for LIMIT

### DIFF
--- a/chaos_genius/connectors/base_db.py
+++ b/chaos_genius/connectors/base_db.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import exc as sqlalchemy_exc
@@ -104,7 +105,7 @@ class BaseDb:
         query = query.strip()
         if query[-1] == ";":
             query = query[:-1]
-        if "limit" not in query:
+        if not re.search(r"\s+limit\s+", query, re.IGNORECASE):
             query += " limit 1 "
 
         query_text = text(query)


### PR DESCRIPTION
Before applying our own `LIMIT 1`, we check if the query already has a `LIMIT` clause by a simple substring search. This had two issues:
- It did not work when `LIMIT` was in uppercase
- It could match "limit" in a column or table name

Changed this to use a case-insensitive regex search which also looks for whitespace around `LIMIT`. Since "limit" as a column or table name will need to enclosed in double quotes, this regex will not match them.