### PR TITLE
Revert "chore(deps): bump pandas from 1.4.4 to 1.5.0"

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -61,7 +61,7 @@ slack-sdk==3.18.3
 matplotlib==3.4.2
 numpy==1.23.3
 numpyencoder==0.3.0
-pandas==1.5.0
+pandas==1.4.4
 statsmodels==0.13.2
 prophet==1.1.1
 # neuralprophet==0.2.7


### PR DESCRIPTION
Reverts chaos-genius/chaos_genius#1134

`snowflake-connector-python` does not support pandas 1.5.0 yet. See: https://github.com/chaos-genius/chaos_genius/actions/runs/3104998273/jobs/5030104548#step:4:387