### PR TITLE
docs: Add troubleshooting guideline for local setup - PIP Version and Missing Python Headers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,35 @@ Steps to set up a development environment:
     ```
 - Note: this does not start any of the celery schedulers or workers, which are needed if you want to run any analytics.
 
+#### *Troubleshooting*
+a> If you come across cases where python libraries are failing with this error 
+ ```
+ERROR: Failed building wheel for numpy
+ Failed to build pyarrow numpy
+ERROR: Could not build wheels for pyarrow, numpy which use PEP 517 and cannot be installed directly
+```
+
+Resolution -> Upgrade your pip version 
+
+b> Missing Python.h file
+```
+lib/zoneinfo_module.c:1:10: fatal error: 'Python.h' file not found
+    #include "Python.h"
+         ^~~~~~~~~~
+    1 error generated.
+    error: command '/usr/bin/clang' failed with exit code 1
+    [end of output]
+  
+ note: This error originates from a subprocess, and is likely not a problem with pip.
+ ERROR: Failed building wheel for backports.zoneinfo
+Successfully built PyYAML prophet
+Failed to build backports.zoneinfo
+ERROR: Could not build wheels for backports.zoneinfo, which is required to install pyproject.toml-based projects
+```
+
+Resolution -> This requires python development files. You could refer this [link](https://stackoverflow.com/questions/21530577/fatal-error-python-h-no-such-file-or-directory) and install the library according to your system configuration. 
+For mac users, if you have installed python through homebrew then you can skip it as homebrew includes development files. If you would like to reinstall it then run `brew reinstall python`.
+
 #### **Frontend/UI/Webapp**
 
 Prerequisites:


### PR DESCRIPTION
I have updated the contribution docs with two resolution of errors for local setup. 